### PR TITLE
draft: feat: adds `DuckShellRouterDelegate` and update `currentRouterDelegate` type

### DIFF
--- a/flutter/packages/duck_router/lib/src/shell.dart
+++ b/flutter/packages/duck_router/lib/src/shell.dart
@@ -7,6 +7,7 @@ import 'package:duck_router/src/provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+
 import 'navigator.dart';
 
 /// {@template duck_shell}
@@ -191,20 +192,29 @@ class DuckShellState extends State<DuckShell> {
     });
   }
 
-  RouterDelegate get currentRouterDelegate => _routerDelegates[_currentIndex];
+  DuckShellRouterDelegate get currentRouterDelegate =>
+      _routerDelegates[_currentIndex];
 }
 
 typedef _NewPathCallback = void Function(LocationStack configuration);
 
-class _NestedRouterDelegate extends RouterDelegate<LocationStack>
+abstract class DuckShellRouterDelegate extends RouterDelegate<LocationStack> {
+  DuckShellRouterDelegate({
+    required LocationStack stack,
+  }) : currentConfiguration = stack;
+
+  @override
+  LocationStack currentConfiguration;
+}
+
+class _NestedRouterDelegate extends DuckShellRouterDelegate
     with ChangeNotifier, PopNavigatorRouterDelegateMixin<LocationStack> {
   _NestedRouterDelegate({
     required GlobalKey<NavigatorState> navigatorKey,
-    required LocationStack stack,
+    required super.stack,
     required _NewPathCallback onNewPath,
     required DuckRouterConfiguration configuration,
   })  : _navigatorKey = navigatorKey,
-        currentConfiguration = stack,
         _onNewPath = onNewPath,
         _routerConfiguration = configuration;
 
@@ -237,9 +247,6 @@ class _NestedRouterDelegate extends RouterDelegate<LocationStack>
     final currentLocation = currentConfiguration.locations.last;
     _routerConfiguration.removeLocation(currentLocation, result);
   }
-
-  @override
-  LocationStack currentConfiguration;
 
   @override
   GlobalKey<NavigatorState> get navigatorKey => _navigatorKey;


### PR DESCRIPTION
Hi @JaspervanRiet. I wanted to provide some proof of concept for what I would like for resolving #30

## Description

This adds better more useful typing to `DuckShellState.currentRouterDelegate` in order to resolves challenges discussed in #30.


If the lint `avoid_dynamic_calls` is enabled then we'd run into lint issues below
![image](https://github.com/user-attachments/assets/ce2117a5-2e9b-4f47-a403-764f12695e05)

```dart
Location current(DuckRouter router) {
  var last = router.routerDelegate.currentConfiguration.locations.last;
  if (last is StatefulLocation) {
    // currentConfiguration is dynamic:
    // Method invocation or property access on a 'dynamic' target.
    // Try giving the target a type.
    return last.state.currentRouterDelegate.currentConfiguration.locations.last;
  }
  return last;
}
```

But after this change we don't need to access the `currentConfiguration` object dynamically as it's typed to `LocationStack currentConfiguration` which is the underlying type.

## Related Issues

#30

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [X] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.

---

