### PR TITLE
feat: add support for NavigatorObservers

### DIFF
--- a/duck_router/README.md
+++ b/duck_router/README.md
@@ -232,7 +232,7 @@ DuckRouter.of(context).navigate(to: DialogPageLocation);
 
 ## Navigator observers
 
-Adding a solid support for [NavigatorObservers](https://api.flutter.dev/flutter/widgets/NavigatorObserver-class.html) is not trivial, due to the many limitations it has, and the fact we want to hide the implementation details of this package as much as possible.
+Adding support for [NavigatorObservers](https://api.flutter.dev/flutter/widgets/NavigatorObserver-class.html) to the standard we would like is not trivial, due to the many limitations it has, and the fact we want to hide the implementation details of this package as much as possible.
 
 Because of this, the support for this feature is kept basic, and users of this feature should be aware of the limitations!
 - Observers should always be **stateless**

--- a/duck_router/README.md
+++ b/duck_router/README.md
@@ -229,3 +229,30 @@ And to open it, all we do is:
 ```dart
 DuckRouter.of(context).navigate(to: DialogPageLocation);
 ```
+
+## Navigator observers
+
+Adding a solid support for [NavigatorObservers](https://api.flutter.dev/flutter/widgets/NavigatorObserver-class.html) is not trivial, due to the many limitations it has, and the fact we want to hide the implementation details of this package as much as possible.
+
+Because of this, the support for this feature is kept basic, and users of this feature should be aware of the limitations!
+- Observers should always be **stateless**
+- Observers **can not be shared** between Navigators
+
+When creating the DuckRouter instance, it is possible to pass a builder function for adding NavigatorObservers to each (nested) navigator, like the example below:
+
+```dart
+final router = DuckRouter(
+  initialLocation: RootLocation(),
+  onDeepLink: (uri, currentLocation) {
+    return [const DetailLocation()];
+  },
+  interceptors: [AuthInterceptor()],
+  navigatorObserverBuilder: (navigatorKey) {
+    return [
+      LoggerNavigatorObserver(),
+    ];
+  },
+);
+```
+
+This builder will be called for every Navigator that is created. Because of the limitations above, it is important that each time this callback is triggered, new instances of the observers are returned!

--- a/duck_router/example/lib/main.dart
+++ b/duck_router/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 import 'package:duck_router/duck_router.dart';
 
@@ -11,6 +13,11 @@ final router = DuckRouter(
     return [const DetailLocation()];
   },
   interceptors: [AuthInterceptor()],
+  navigatorObserverBuilder: (navigatorKey) {
+    return [
+      LoggerNavigatorObserver(),
+    ];
+  },
 );
 
 bool loggedIn = false;
@@ -247,5 +254,30 @@ class AuthInterceptor extends LocationInterceptor {
       }
     }
     return null;
+  }
+}
+
+class LoggerNavigatorObserver extends NavigatorObserver {
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _logNavigation(route.settings.name, 'push');
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _logNavigation(route.settings.name, 'pop');
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    if (newRoute != null) {
+      _logNavigation(newRoute.settings.name, 'replace');
+    }
+  }
+
+  void _logNavigation(String? routeName, String action) {
+    if (routeName != null) {
+      log("Screen $action: $routeName", name: 'Navigation');
+    }
   }
 }

--- a/duck_router/lib/src/configuration.dart
+++ b/duck_router/lib/src/configuration.dart
@@ -17,6 +17,13 @@ typedef DuckRouterDeepLinkHandler = List<Location>? Function(
 /// A listener for when the router navigates.
 typedef DuckRouterNavigatorListener = void Function(Location destination);
 
+/// A builder that creates a list of [NavigatorObserver]s.
+/// A builder has to be provided, as a [NavigatorObserver] can not be shared between navigators.
+/// The builder is called with the navigator key of the navigator that the observers are for.
+/// Note that the observers returned by the builder should not be shared between navigators!
+typedef DuckRouterNavigatorObserverBuilder = List<NavigatorObserver> Function(
+    GlobalKey<NavigatorState> navigatorKey);
+
 /// {@template duck_router_configuration}
 /// A configuration object for the [DuckRouter].
 /// {@endtemplate}
@@ -28,6 +35,7 @@ class DuckRouterConfiguration {
     this.interceptors,
     this.onDeepLink,
     this.onNavigate,
+    this.navigatorObserverBuilder,
   }) : rootNavigatorKey = rootNavigatorKey ?? GlobalKey<NavigatorState>();
 
   /// The list of locations that the user can route to
@@ -48,6 +56,12 @@ class DuckRouterConfiguration {
 
   /// A listener for when the router navigates.
   final DuckRouterNavigatorListener? onNavigate;
+
+  /// A builder that creates a list of [NavigatorObserver]s.
+  /// A builder has to be provided, as a [NavigatorObserver] can not be shared between navigators.
+  /// The builder is called with the navigator key of the navigator that the observers are for.
+  /// Note that the observers returned by the builder should not be shared between navigators!
+  final DuckRouterNavigatorObserverBuilder? navigatorObserverBuilder;
 
   final Map<String, LocationMatch> _routeMapping = {};
 

--- a/duck_router/lib/src/delegate.dart
+++ b/duck_router/lib/src/delegate.dart
@@ -34,6 +34,9 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
         stack: currentConfiguration,
         onPopPage: _onPopPage,
         onDidRemovePage: _onDidRemovePage,
+        observers: _configuration.navigatorObserverBuilder != null
+            ? _configuration.navigatorObserverBuilder!(navigatorKey)
+            : null,
       ),
     );
   }

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -34,6 +34,7 @@ class DuckRouter implements RouterConfig<LocationStack> {
     List<LocationInterceptor>? interceptors,
     DuckRouterDeepLinkHandler? onDeepLink,
     DuckRouterNavigatorListener? onNavigate,
+    DuckRouterNavigatorObserverBuilder? navigatorObserverBuilder,
   }) {
     return DuckRouter.withConfig(
       configuration: DuckRouterConfiguration(
@@ -41,6 +42,7 @@ class DuckRouter implements RouterConfig<LocationStack> {
         interceptors: interceptors,
         onDeepLink: onDeepLink,
         onNavigate: onNavigate,
+        navigatorObserverBuilder: navigatorObserverBuilder,
       ),
     );
   }

--- a/duck_router/lib/src/navigator.dart
+++ b/duck_router/lib/src/navigator.dart
@@ -14,6 +14,7 @@ class DuckNavigator extends StatefulWidget {
     required this.navigatorKey,
     required this.onPopPage,
     required this.onDidRemovePage,
+    this.observers,
     super.key,
   });
 
@@ -26,6 +27,8 @@ class DuckNavigator extends StatefulWidget {
   final OnPopInvokedCallback onPopPage;
 
   final DidRemovePageCallback onDidRemovePage;
+
+  final List<NavigatorObserver>? observers;
 
   @override
   State<StatefulWidget> createState() {
@@ -82,6 +85,7 @@ class _DuckNavigatorState extends State<DuckNavigator> {
         key: widget.navigatorKey,
         pages: _pages!,
         onDidRemovePage: widget.onDidRemovePage,
+        observers: widget.observers ?? [],
       ),
     );
   }

--- a/duck_router/lib/src/shell.dart
+++ b/duck_router/lib/src/shell.dart
@@ -219,6 +219,9 @@ class _NestedRouterDelegate extends RouterDelegate<LocationStack>
       stack: currentConfiguration,
       onPopPage: onPopPage,
       onDidRemovePage: _onDidRemovePage,
+      observers: _routerConfiguration.navigatorObserverBuilder != null
+          ? _routerConfiguration.navigatorObserverBuilder!(navigatorKey)
+          : null,
     );
   }
 


### PR DESCRIPTION
## Description

Currently, it is not possible to use NavigatorObservers with duck_router. I mentioned this once in a previous issue, but did not pursue it.

However, this limitation stayed with me, as in other apps (where we do not use duck_router) we do rely quite heavily on these observers. So this PR is my attempt to support these observers and remove that limitation.

You'll notice that unlike the navigatorObservers property in MaterialApp, my solution requires a builder function to be added. So the callback is really meant to create new instances of the observers.

PS: I know this topic can become quite complex, they did not achieve a satisfying result yet in [go_router either](https://github.com/flutter/flutter/issues/112196), but I believe we can get away with this solution for now.

## Related Issues

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
