### PR TITLE
fix: router errors when restoring state

### DIFF
--- a/duck_router/lib/src/parser.dart
+++ b/duck_router/lib/src/parser.dart
@@ -38,7 +38,13 @@ class DuckInformationParser extends RouteInformationParser<LocationStack> {
       final stack =
           _codec.decode(routeInformation.state! as Map<Object?, Object?>);
 
-      return _maybeIntercept(stack.locations.last, stack.locations);
+      return _maybeIntercept(
+          stack.locations.last,
+          // Before rebuild:
+          // - /home/page1
+          // Then we rebuild, so we need to remove page1, otherwise
+          // we will have /home/page1/page1
+          stack.locations.sublist(0, stack.locations.length - 1));
     }
 
     final currentStack = state.baseLocationStack.locations;

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: prefer_const_constructors, unawaited_futures
 
+import 'dart:async';
+
 import 'package:duck_router/src/configuration.dart';
 import 'package:duck_router/src/exception.dart';
 import 'package:duck_router/src/location.dart';
@@ -354,6 +356,20 @@ void main() {
                   'When using a custom DuckPage, you must override createRoute'));
         }
       });
+    });
+
+    testWidgets('Does not error when refreshing app', (tester) async {
+      StreamController<int> streamController =
+          StreamController<int>.broadcast();
+
+      await tester.pumpWidget(
+        RefreshableApp(stream: streamController.stream),
+      );
+
+      streamController.add(1);
+      await tester.pumpAndSettle();
+
+      streamController.close();
     });
   });
 

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -358,6 +358,10 @@ void main() {
       });
     });
 
+    /// See https://github.com/JaspervanRiet/duck_router/issues/40
+    ///
+    /// This test is to ensure that the router does not error when
+    /// it has to restore itself.
     testWidgets('Does not error when refreshing app', (tester) async {
       StreamController<int> streamController =
           StreamController<int>.broadcast();
@@ -366,7 +370,16 @@ void main() {
         RefreshableApp(stream: streamController.stream),
       );
 
+      // This will navigate to a new page. We do this
+      // to ensure that we're not just fixing a duplication issue
+      // for the initial location, but in general instead.
       streamController.add(1);
+      await tester.pumpAndSettle();
+
+      // This will trigger a rebuild of the app,
+      // including the router. That will trigger
+      // a restoration of the router.
+      streamController.add(2);
       await tester.pumpAndSettle();
 
       streamController.close();

--- a/duck_router/test/src/test_helpers.dart
+++ b/duck_router/test/src/test_helpers.dart
@@ -324,3 +324,40 @@ class FaultyCustomPage<T> extends DuckPage<T> {
     super.name = 'faulty-custom-page',
   }) : super.custom();
 }
+
+class RefreshableApp extends StatelessWidget {
+  RefreshableApp({
+    required this.stream,
+    super.key,
+  });
+
+  final Stream<int> stream;
+
+  final DuckRouter router = DuckRouter(
+    initialLocation: HomeLocation(),
+    interceptors: [],
+  );
+
+  final appKey = GlobalKey();
+
+  @override
+  Widget build(BuildContext context) {
+    Widget child = KeyedSubtree(
+      key: appKey,
+      child: MaterialApp.router(
+        routerConfig: router,
+      ),
+    );
+
+    return StreamBuilder(
+        stream: stream,
+        builder: (context, s) {
+          if (s.data == 1) {
+            child = Container(
+              child: child,
+            );
+          }
+          return child;
+        });
+  }
+}

--- a/duck_router/test/src/test_helpers.dart
+++ b/duck_router/test/src/test_helpers.dart
@@ -353,6 +353,9 @@ class RefreshableApp extends StatelessWidget {
         stream: stream,
         builder: (context, s) {
           if (s.data == 1) {
+            router.navigate(to: Page1Location());
+          }
+          if (s.data == 2) {
             child = Container(
               child: child,
             );


### PR DESCRIPTION
## Description

This PR fixes an issue where restoring the state, as documented by the example in #40 and in the new test, would cause an error. This was because the top location in the stack was getting duplicated when restoring. For example, you would have `/home`. When restoring the router, this would become `/home/home` with the exact same objects, and thus a crash would follow.

## Related Issues

Fixes #40 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.
