### PR TITLE
fix!: allow awaiting custom page navigation

### DIFF
--- a/duck_router/doc/custom-pages.md
+++ b/duck_router/doc/custom-pages.md
@@ -11,7 +11,6 @@ class CustomPageTransitionLocation extends Location {
 
   @override
   LocationPageBuilder get pageBuilder => (context) => DuckPage(
-        name: path,
         child: HomeScreen(),
         transitionsBuilder: (context, animation, secondaryAnimation, child) =>
             FadeTransition(opacity: animation, child: child),
@@ -26,7 +25,6 @@ Let's take the case of a dialog (but you can implement any type of Route in this
 ```dart
 class DialogPage<T> extends DuckPage<T> {
   const DialogPage({
-    required super.name,
     required this.builder,
   }) : super.custom();
 

--- a/duck_router/doc/custom-pages.md
+++ b/duck_router/doc/custom-pages.md
@@ -26,19 +26,16 @@ Let's take the case of a dialog (but you can implement any type of Route in this
 ```dart
 class DialogPage<T> extends DuckPage<T> {
   const DialogPage({
-    required String name,
+    required super.name,
     required this.builder,
-    super.key,
-    super.arguments,
-    super.restorationId,
-  }) : super.custom(name: name);
+  }) : super.custom();
 
   final WidgetBuilder builder;
 
    @override
-   Route<T> createRoute(BuildContext context) => DialogRoute<T>(
+   Route<T> createRoute(context, settings) => DialogRoute<T>(
          context: context,
-         settings: this,
+         settings: settings,
          builder: (context) => Dialog(
            child: builder(context),
          ),

--- a/duck_router/lib/duck_router.dart
+++ b/duck_router/lib/duck_router.dart
@@ -6,4 +6,4 @@ export 'src/interceptor.dart';
 export 'src/location.dart';
 export 'src/duck_router.dart';
 export 'src/shell.dart';
-export 'src/pages/custom.dart';
+export 'src/pages/page.dart';

--- a/duck_router/lib/src/delegate.dart
+++ b/duck_router/lib/src/delegate.dart
@@ -1,10 +1,8 @@
 import 'package:collection/collection.dart';
-import 'package:duck_router/src/duck_router.dart';
+import 'package:duck_router/duck_router.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:duck_router/src/configuration.dart';
 import 'package:duck_router/src/exception.dart';
-import 'package:duck_router/src/location.dart';
 
 import 'navigator.dart';
 

--- a/duck_router/lib/src/location.dart
+++ b/duck_router/lib/src/location.dart
@@ -79,7 +79,6 @@ typedef LocationBuilder = Widget Function(BuildContext context);
 ///   final WidgetBuilder builder;
 ///
 ///   const DialogPage.custom({
-///     required super.name,
 ///     required this.builder,
 ///     this.anchorPoint,
 ///     this.barrierColor = Colors.black87,
@@ -88,7 +87,7 @@ typedef LocationBuilder = Widget Function(BuildContext context);
 ///     this.useSafeArea = true,
 ///     this.themes,
 ///     super.restorationId,
-///   }) : super.custom(name: name);
+///   }) : super.custom();
 ///
 ///   @override
 ///   Route<T> createRoute(BuildContext context, RouteSettings? settings) => DialogRoute<T>(

--- a/duck_router/lib/src/location.dart
+++ b/duck_router/lib/src/location.dart
@@ -79,7 +79,7 @@ typedef LocationBuilder = Widget Function(BuildContext context);
 ///   final WidgetBuilder builder;
 ///
 ///   const DialogPage.custom({
-///     required String name,
+///     required super.name,
 ///     required this.builder,
 ///     this.anchorPoint,
 ///     this.barrierColor = Colors.black87,
@@ -87,15 +87,13 @@ typedef LocationBuilder = Widget Function(BuildContext context);
 ///     this.barrierLabel,
 ///     this.useSafeArea = true,
 ///     this.themes,
-///     super.key,
-///     super.arguments,
 ///     super.restorationId,
 ///   }) : super.custom(name: name);
 ///
 ///   @override
-///   Route<T> createRoute(BuildContext context) => DialogRoute<T>(
+///   Route<T> createRoute(BuildContext context, RouteSettings? settings) => DialogRoute<T>(
 ///         context: context,
-///         settings: this,
+///         settings: settings,
 ///         builder: (context) => Dialog(
 ///           child: builder(context),
 ///         ),

--- a/duck_router/lib/src/navigator.dart
+++ b/duck_router/lib/src/navigator.dart
@@ -1,6 +1,5 @@
-import 'package:duck_router/src/exception.dart';
+import 'package:duck_router/duck_router.dart';
 import 'package:flutter/material.dart';
-import 'package:duck_router/src/location.dart';
 import 'pages/cupertino.dart';
 import 'pages/material.dart';
 
@@ -112,10 +111,12 @@ class _DuckNavigatorState extends State<DuckNavigator> {
           'Location must have a builder or a pageBuilder');
       if (l.pageBuilder != null) {
         final customPage = l.pageBuilder!(context);
-        if (customPage.name == null) {
-          throw const DuckRouterException('Custom pages must have a name set.');
-        }
-        pages.add(customPage);
+        pages.add(
+          pageBuilderForCustomPage(
+            page: customPage,
+            onPopInvoked: widget.onPopPage,
+          ),
+        );
       } else {
         pages.add(_buildPage(l));
       }

--- a/duck_router/lib/src/navigator.dart
+++ b/duck_router/lib/src/navigator.dart
@@ -114,6 +114,8 @@ class _DuckNavigatorState extends State<DuckNavigator> {
           pageBuilderForCustomPage(
             page: customPage,
             onPopInvoked: widget.onPopPage,
+            key: ValueKey(l.path),
+            path: l.path,
           ),
         );
       } else {

--- a/duck_router/lib/src/navigator.dart
+++ b/duck_router/lib/src/navigator.dart
@@ -1,7 +1,6 @@
 import 'package:duck_router/duck_router.dart';
+import 'package:duck_router/src/pages/pages.dart';
 import 'package:flutter/material.dart';
-import 'pages/cupertino.dart';
-import 'pages/material.dart';
 
 /// {@template duck_navigator}
 /// A [Navigator] for a [LocationStack].

--- a/duck_router/lib/src/pages/custom.dart
+++ b/duck_router/lib/src/pages/custom.dart
@@ -1,150 +1,9 @@
-import 'package:duck_router/src/exception.dart';
 import 'package:duck_router/src/navigator.dart';
-import 'package:flutter/material.dart';
-
-typedef TransitionBuilder = Widget Function(
-  BuildContext context,
-  Animation<double> animation,
-  Animation<double> secondaryAnimation,
-  Widget child,
-);
-
-/// {@template duck_page}
-/// DuckPage is a [Page] that integrates with DuckRouter, and can provide more
-/// control over the transition and behavior of a page.
-///
-/// For example:
-///
-/// ```dart
-/// DuckPage(
-///   child: MyPage(),
-///   transitionsBuilder: (c, a, s, child) {
-///     return FadeTransition(
-///       opacity: a,
-///       child: child,
-///     );
-///   },
-/// )
-/// ```
-///
-/// You can use the [DuckPage.custom] constructor to build a fully custom route,
-/// such as a dialog.
-///
-/// See also:
-/// - [LocationPageBuilder]: a builder that allows returning a custom [Page]
-/// for a location.
-///
-/// {@endtemplate}
-///
-/// {@category Custom pages and transitions}
-class DuckPage<T> {
-  /// {@macro duck_page}
-  const DuckPage({
-    required this.name,
-    required this.child,
-    required this.transitionsBuilder,
-    this.isModal = false,
-    this.transitionDuration = const Duration(milliseconds: 300),
-    this.reverseTransitionDuration = const Duration(milliseconds: 300),
-    this.maintainState = false,
-    this.canTapToDismiss = false,
-    this.backgroundColor,
-    this.semanticLabel,
-  })  : assert(child != null),
-        assert(transitionsBuilder != null);
-
-  /// Creates a custom [DuckPage].
-  ///
-  /// When using this constructor, you must override [createRoute] to return a
-  /// custom [Route].
-  const DuckPage.custom({
-    required this.name,
-    this.isModal = false,
-    this.transitionDuration = const Duration(milliseconds: 300),
-    this.reverseTransitionDuration = const Duration(milliseconds: 300),
-    this.maintainState = false,
-    this.canTapToDismiss = false,
-    this.backgroundColor,
-    this.semanticLabel,
-  })  : child = null,
-        transitionsBuilder = null;
-
-  final String name;
-
-  /// Content of this page.
-  final Widget? child;
-
-  /// Duration of the transition.
-  ///
-  /// Defaults to 300ms.
-  final Duration transitionDuration;
-
-  /// Duration of the reverse transition.
-  ///
-  /// Defaults to 300ms.
-  final Duration reverseTransitionDuration;
-
-  /// If true, route will stay in memory.
-  ///
-  /// See also:
-  /// - [ModalRoute.maintainState]
-  final bool maintainState;
-
-  /// Set to true to make this page route a modal page, which is a fullscreen
-  /// page that covers the entire screen and shows an X instead of a back
-  /// button.
-  final bool isModal;
-
-  /// Set to true to allow dismissing the route by tapping.
-  ///
-  /// Defaults to false.
-  final bool canTapToDismiss;
-
-  /// The color to use as background color for the route.
-  ///
-  /// If this is null, the barrier will be transparent.
-  ///
-  /// See also:
-  /// - [ModalRoute.barrierColor]
-  final Color? backgroundColor;
-
-  /// The semantic label used if this route can be dismissed by tapping.
-  ///
-  /// See also:
-  /// - [ModalRoute.barrierLabel]
-  /// - [canTapToDismiss]
-  final String? semanticLabel;
-
-  /// Use the [transitionsBuilder] to define custom transitions for this page.
-  ///
-  /// This transition will wrap the [child] widget.
-  ///
-  /// See also:
-  /// - [ModalRoute.buildTransitions] for more information on how to use this.
-  final TransitionBuilder? transitionsBuilder;
-
-  /// Creates a [Route] for this page.
-  ///
-  /// You should override this if you are using the [DuckPage.custom]
-  /// constructor.
-  ///
-  /// That will enable you to create a fully custom route, such as a dialog via
-  /// DialogRoute, or a CupertinoPageRoute, or any other custom route.
-  Route<T>? createRoute(
-    BuildContext context, {
-    RouteSettings? settings,
-  }) {
-    if (child == null || transitionsBuilder == null) {
-      throw const DuckRouterException(
-        'When using a custom DuckPage, you must override createRoute',
-      );
-    }
-    return null;
-  }
-}
+import 'package:duck_router/src/pages/page.dart' as duck_page;
+import 'package:flutter/widgets.dart';
 
 Page<T> pageBuilderForCustomPage<T>({
-  required DuckPage<T> page,
+  required duck_page.DuckPage<T> page,
   required OnPopInvokedCallback onPopInvoked,
 }) =>
     _DuckPage<T>(
@@ -154,7 +13,7 @@ Page<T> pageBuilderForCustomPage<T>({
 
 class _DuckPage<T> extends Page<T> {
   _DuckPage(
-    DuckPage<T> page, {
+    duck_page.DuckPage<T> page, {
     required OnPopInvokedCallback onPopInvoked,
   })  : child = page.child,
         transitionDuration = page.transitionDuration,
@@ -171,7 +30,7 @@ class _DuckPage<T> extends Page<T> {
           onPopInvoked: onPopInvoked,
         );
 
-  final DuckPage<T> _page;
+  final duck_page.DuckPage<T> _page;
 
   /// Content of this page.
   final Widget? child;
@@ -223,7 +82,7 @@ class _DuckPage<T> extends Page<T> {
   ///
   /// See also:
   /// - [ModalRoute.buildTransitions] for more information on how to use this.
-  final TransitionBuilder? transitionsBuilder;
+  final duck_page.TransitionBuilder? transitionsBuilder;
 
   @override
   Route<T> createRoute(BuildContext context) {

--- a/duck_router/lib/src/pages/custom.dart
+++ b/duck_router/lib/src/pages/custom.dart
@@ -14,7 +14,7 @@ Page<T> pageBuilderForCustomPage<T>({
 class _DuckPage<T> extends Page<T> {
   _DuckPage(
     duck_page.DuckPage<T> page, {
-    required OnPopInvokedCallback onPopInvoked,
+    super.onPopInvoked,
   })  : child = page.child,
         transitionDuration = page.transitionDuration,
         reverseTransitionDuration = page.reverseTransitionDuration,
@@ -27,7 +27,8 @@ class _DuckPage<T> extends Page<T> {
         _page = page,
         super(
           name: page.name,
-          onPopInvoked: onPopInvoked,
+          canPop: page.canPop ?? true,
+          restorationId: page.restorationId,
         );
 
   final duck_page.DuckPage<T> _page;
@@ -86,11 +87,7 @@ class _DuckPage<T> extends Page<T> {
 
   @override
   Route<T> createRoute(BuildContext context) {
-    return _page.createRoute(
-          context,
-          settings: this,
-        ) ??
-        _DuckPageRoute<T>(this);
+    return _page.createRoute(context, this) ?? _DuckPageRoute<T>(this);
   }
 }
 

--- a/duck_router/lib/src/pages/custom.dart
+++ b/duck_router/lib/src/pages/custom.dart
@@ -5,16 +5,18 @@ import 'package:flutter/widgets.dart';
 Page<T> pageBuilderForCustomPage<T>({
   required duck_page.DuckPage<T> page,
   required OnPopInvokedCallback onPopInvoked,
+  required LocalKey key,
+  required String path,
 }) =>
-    _DuckPage<T>(
-      page,
-      onPopInvoked: onPopInvoked,
-    );
+    _DuckPage<T>(page, onPopInvoked: onPopInvoked, key: key, name: path);
 
 class _DuckPage<T> extends Page<T> {
   _DuckPage(
     duck_page.DuckPage<T> page, {
+    required super.key,
+    required super.name,
     super.onPopInvoked,
+    super.canPop,
   })  : child = page.child,
         transitionDuration = page.transitionDuration,
         reverseTransitionDuration = page.reverseTransitionDuration,
@@ -26,8 +28,6 @@ class _DuckPage<T> extends Page<T> {
         transitionsBuilder = page.transitionsBuilder,
         _page = page,
         super(
-          name: page.name,
-          canPop: page.canPop ?? true,
           restorationId: page.restorationId,
         );
 

--- a/duck_router/lib/src/pages/page.dart
+++ b/duck_router/lib/src/pages/page.dart
@@ -9,7 +9,7 @@ typedef TransitionBuilder = Widget Function(
 );
 
 /// {@template duck_page}
-/// DuckPage is a [Page] that integrates with DuckRouter, and can provide more
+/// DuckPage allows you to create a custom page, such as a modal, with DuckRouter, and can provide more
 /// control over the transition and behavior of a page.
 ///
 /// For example:
@@ -49,6 +49,8 @@ class DuckPage<T> {
     this.canTapToDismiss = false,
     this.backgroundColor,
     this.semanticLabel,
+    this.restorationId,
+    this.canPop,
   })  : assert(child != null),
         assert(transitionsBuilder != null);
 
@@ -65,6 +67,8 @@ class DuckPage<T> {
     this.canTapToDismiss = false,
     this.backgroundColor,
     this.semanticLabel,
+    this.restorationId,
+    this.canPop,
   })  : child = null,
         transitionsBuilder = null;
 
@@ -122,6 +126,12 @@ class DuckPage<T> {
   /// - [ModalRoute.buildTransitions] for more information on how to use this.
   final TransitionBuilder? transitionsBuilder;
 
+  /// See [RouteSettings.arguments]
+  final String? restorationId;
+
+  /// If set to false, the route will not be able to pop.
+  final bool? canPop;
+
   /// Creates a [Route] for this page.
   ///
   /// You should override this if you are using the [DuckPage.custom]
@@ -130,9 +140,9 @@ class DuckPage<T> {
   /// That will enable you to create a fully custom route, such as a dialog via
   /// DialogRoute, or a CupertinoPageRoute, or any other custom route.
   Route<T>? createRoute(
-    BuildContext context, {
+    BuildContext context,
     RouteSettings? settings,
-  }) {
+  ) {
     if (child == null || transitionsBuilder == null) {
       throw const DuckRouterException(
         'When using a custom DuckPage, you must override createRoute',

--- a/duck_router/lib/src/pages/page.dart
+++ b/duck_router/lib/src/pages/page.dart
@@ -1,0 +1,143 @@
+import 'package:duck_router/src/exception.dart';
+import 'package:flutter/widgets.dart';
+
+typedef TransitionBuilder = Widget Function(
+  BuildContext context,
+  Animation<double> animation,
+  Animation<double> secondaryAnimation,
+  Widget child,
+);
+
+/// {@template duck_page}
+/// DuckPage is a [Page] that integrates with DuckRouter, and can provide more
+/// control over the transition and behavior of a page.
+///
+/// For example:
+///
+/// ```dart
+/// DuckPage(
+///   child: MyPage(),
+///   transitionsBuilder: (c, a, s, child) {
+///     return FadeTransition(
+///       opacity: a,
+///       child: child,
+///     );
+///   },
+/// )
+/// ```
+///
+/// You can use the [DuckPage.custom] constructor to build a fully custom route,
+/// such as a dialog.
+///
+/// See also:
+/// - [LocationPageBuilder]: a builder that allows returning a custom [Page]
+/// for a location.
+///
+/// {@endtemplate}
+///
+/// {@category Custom pages and transitions}
+class DuckPage<T> {
+  /// {@macro duck_page}
+  const DuckPage({
+    required this.name,
+    required this.child,
+    required this.transitionsBuilder,
+    this.isModal = false,
+    this.transitionDuration = const Duration(milliseconds: 300),
+    this.reverseTransitionDuration = const Duration(milliseconds: 300),
+    this.maintainState = false,
+    this.canTapToDismiss = false,
+    this.backgroundColor,
+    this.semanticLabel,
+  })  : assert(child != null),
+        assert(transitionsBuilder != null);
+
+  /// Creates a custom [DuckPage].
+  ///
+  /// When using this constructor, you must override [createRoute] to return a
+  /// custom [Route].
+  const DuckPage.custom({
+    required this.name,
+    this.isModal = false,
+    this.transitionDuration = const Duration(milliseconds: 300),
+    this.reverseTransitionDuration = const Duration(milliseconds: 300),
+    this.maintainState = false,
+    this.canTapToDismiss = false,
+    this.backgroundColor,
+    this.semanticLabel,
+  })  : child = null,
+        transitionsBuilder = null;
+
+  final String name;
+
+  /// Content of this page.
+  final Widget? child;
+
+  /// Duration of the transition.
+  ///
+  /// Defaults to 300ms.
+  final Duration transitionDuration;
+
+  /// Duration of the reverse transition.
+  ///
+  /// Defaults to 300ms.
+  final Duration reverseTransitionDuration;
+
+  /// If true, route will stay in memory.
+  ///
+  /// See also:
+  /// - [ModalRoute.maintainState]
+  final bool maintainState;
+
+  /// Set to true to make this page route a modal page, which is a fullscreen
+  /// page that covers the entire screen and shows an X instead of a back
+  /// button.
+  final bool isModal;
+
+  /// Set to true to allow dismissing the route by tapping.
+  ///
+  /// Defaults to false.
+  final bool canTapToDismiss;
+
+  /// The color to use as background color for the route.
+  ///
+  /// If this is null, the barrier will be transparent.
+  ///
+  /// See also:
+  /// - [ModalRoute.barrierColor]
+  final Color? backgroundColor;
+
+  /// The semantic label used if this route can be dismissed by tapping.
+  ///
+  /// See also:
+  /// - [ModalRoute.barrierLabel]
+  /// - [canTapToDismiss]
+  final String? semanticLabel;
+
+  /// Use the [transitionsBuilder] to define custom transitions for this page.
+  ///
+  /// This transition will wrap the [child] widget.
+  ///
+  /// See also:
+  /// - [ModalRoute.buildTransitions] for more information on how to use this.
+  final TransitionBuilder? transitionsBuilder;
+
+  /// Creates a [Route] for this page.
+  ///
+  /// You should override this if you are using the [DuckPage.custom]
+  /// constructor.
+  ///
+  /// That will enable you to create a fully custom route, such as a dialog via
+  /// DialogRoute, or a CupertinoPageRoute, or any other custom route.
+  Route<T>? createRoute(
+    BuildContext context, {
+    RouteSettings? settings,
+  }) {
+    if (child == null || transitionsBuilder == null) {
+      throw const DuckRouterException(
+        'When using a custom DuckPage, you must override createRoute',
+      );
+    }
+    return null;
+  }
+}

--- a/duck_router/lib/src/pages/page.dart
+++ b/duck_router/lib/src/pages/page.dart
@@ -39,7 +39,6 @@ typedef TransitionBuilder = Widget Function(
 class DuckPage<T> {
   /// {@macro duck_page}
   const DuckPage({
-    required this.name,
     required this.child,
     required this.transitionsBuilder,
     this.isModal = false,
@@ -59,7 +58,6 @@ class DuckPage<T> {
   /// When using this constructor, you must override [createRoute] to return a
   /// custom [Route].
   const DuckPage.custom({
-    required this.name,
     this.isModal = false,
     this.transitionDuration = const Duration(milliseconds: 300),
     this.reverseTransitionDuration = const Duration(milliseconds: 300),
@@ -71,8 +69,6 @@ class DuckPage<T> {
     this.canPop,
   })  : child = null,
         transitionsBuilder = null;
-
-  final String name;
 
   /// Content of this page.
   final Widget? child;

--- a/duck_router/lib/src/pages/pages.dart
+++ b/duck_router/lib/src/pages/pages.dart
@@ -1,3 +1,4 @@
 export 'cupertino.dart';
 export 'custom.dart';
 export 'material.dart';
+export 'page.dart';

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -301,6 +301,28 @@ void main() {
         expect(find.byType(CustomScreen), findsOneWidget);
       });
 
+      testWidgets('can await navigate to custom page', (tester) async {
+        final config = DuckRouterConfiguration(
+          initialLocation: HomeLocation(),
+        );
+
+        final router = await createRouter(config, tester);
+        final locations = router.routerDelegate.currentConfiguration;
+        expect(locations.uri.path, '/home');
+
+        int result = 0;
+        router.navigate<int>(to: CustomPageLocation()).then((value) {
+          return result = value!;
+        });
+        await tester.pumpAndSettle();
+        expect(find.byType(CustomScreen), findsOneWidget);
+
+        router.pop(1);
+        await tester.pumpAndSettle();
+
+        expect(result, equals(1));
+      });
+
       testWidgets('can specify custom page transition', (tester) async {
         final config = DuckRouterConfiguration(
           initialLocation: CustomPageTransitionLocation(),

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -368,7 +368,7 @@ void main() {
 
         final page = FaultyCustomPage();
         try {
-          page.createRoute(context);
+          page.createRoute(context, null);
           fail('Should have thrown an error');
         } catch (e) {
           expect(e, isInstanceOf<DuckRouterException>());

--- a/duck_router/test/src/test_helpers.dart
+++ b/duck_router/test/src/test_helpers.dart
@@ -287,7 +287,6 @@ class CustomPageTransitionLocation extends Location {
 
   @override
   LocationPageBuilder get pageBuilder => (context) => DuckPage(
-        name: path,
         child: HomeScreen(),
         transitionsBuilder: (context, animation, secondaryAnimation, child) =>
             FadeTransition(opacity: animation, child: child),
@@ -295,9 +294,7 @@ class CustomPageTransitionLocation extends Location {
 }
 
 class CustomPage<T> extends DuckPage<T> {
-  const CustomPage({
-    super.name = 'custom-page',
-  }) : super.custom();
+  const CustomPage() : super.custom();
 
   @override
   Route<T> createRoute(BuildContext context, RouteSettings? settings) {
@@ -320,9 +317,7 @@ class CustomScreen extends StatelessWidget {
 /// This is a faulty custom implementation because it uses the custom constructor
 /// without overriding `createRoute`.
 class FaultyCustomPage<T> extends DuckPage<T> {
-  const FaultyCustomPage({
-    super.name = 'faulty-custom-page',
-  }) : super.custom();
+  const FaultyCustomPage() : super.custom();
 }
 
 class RefreshableApp extends StatelessWidget {

--- a/duck_router/test/src/test_helpers.dart
+++ b/duck_router/test/src/test_helpers.dart
@@ -300,7 +300,7 @@ class CustomPage<T> extends DuckPage<T> {
   }) : super.custom();
 
   @override
-  Route<T> createRoute(BuildContext context, {RouteSettings? settings}) {
+  Route<T> createRoute(BuildContext context, RouteSettings? settings) {
     return MaterialPageRoute<T>(
       settings: settings,
       builder: (context) => const CustomScreen(),
@@ -317,7 +317,7 @@ class CustomScreen extends StatelessWidget {
   Widget build(BuildContext context) => const Placeholder();
 }
 
-/// This is a fauly custom implementation because it uses the custom constructor
+/// This is a faulty custom implementation because it uses the custom constructor
 /// without overriding `createRoute`.
 class FaultyCustomPage<T> extends DuckPage<T> {
   const FaultyCustomPage({

--- a/duck_router/test/src/test_helpers.dart
+++ b/duck_router/test/src/test_helpers.dart
@@ -300,9 +300,9 @@ class CustomPage<T> extends DuckPage<T> {
   }) : super.custom();
 
   @override
-  Route<T> createRoute(BuildContext context) {
+  Route<T> createRoute(BuildContext context, {RouteSettings? settings}) {
     return MaterialPageRoute<T>(
-      settings: this,
+      settings: settings,
       builder: (context) => const CustomScreen(),
     );
   }


### PR DESCRIPTION
## Description

As documented by #43, we cannot currently await a `navigate` call to a `DuckPage`. This is an issue caused by the fact we do not provide `onPopInvoked` to the `Page` that `DuckPage` overrides. As a result, we do not call `onPop` in our delegate and never get here: https://github.com/JaspervanRiet/duck_router/blob/5390c2bbb9cdb27bcd5bbd1531ed2d874706e797/duck_router/lib/src/configuration.dart#L87

Solving this can use a number of approaches. My approach here has been very similar to the solution in #31: we want to hide most of this complexity. That means not exposing the popping interface to the user. We can do this by constructing a `Page` object builder in the exact same way that `MaterialPage` and `CupertinoPage` are created. This PR does that by no longer inheriting from `Page` in `DuckPage`. That provides a number of advantages:

- We can use the builder pattern described above
- It allows us to separate our data model from `Page`. #31 already hit a number of inflexibilities, now we can just construct our own model

The only real issue encountered is that we still need to provide the `RouteSettings` in `createRoute` to allow construction of certain routes. That means a small tweak to implementations. Thankfully it's not a functionality change, it's just syntax.

## Related Issues

#43 

## Migration guide

Migration is trivial, since most of the complexity is still hidden:

**BEFORE**

```dart
class CustomPage<T> extends DuckPage<T> {
  const CustomPage({
    super.name = 'custom-page',
  }) : super.custom();

  @override
  Route<T> createRoute(BuildContext context) {
    return MaterialPageRoute<T>(
      settings: this,
      builder: (context) => const CustomScreen(),
    );
  }
}
```

**AFTER**

```dart
class CustomPage<T> extends DuckPage<T> {
  const CustomPage() : super.custom();

  @override
  Route<T> createRoute(BuildContext context, RouteSettings? settings) {
    return MaterialPageRoute<T>(
      settings: settings,
      builder: (context) => const CustomScreen(),
    );
  }
}
```

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.
