### PR TITLE
fix replace & clearStack not completing completers

### DIFF
--- a/duck_router/lib/src/delegate.dart
+++ b/duck_router/lib/src/delegate.dart
@@ -100,7 +100,7 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
     if (currentLocation is StatefulLocation) {
       /// Pop inside the stateful child location as long as that's possible.
       /// Else we will pop the whole route.
-      if (currentLocation.state.currentRouterDelegate.currentConfiguration
+      if (currentLocation.state.currentRouterDelegate.currentConfiguration!
               .locations.length >
           1) {
         return currentLocation.state.pop(result);
@@ -123,7 +123,7 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
     if (currentLocation is StatefulLocation) {
       /// Pop inside the stateful child location as long as that's possible.
       /// Else we will pop the whole route.
-      if (currentLocation.state.currentRouterDelegate.currentConfiguration
+      if (currentLocation.state.currentRouterDelegate.currentConfiguration!
               .locations.length >
           1) {
         final result = currentLocation.state.popUntil(predicate);
@@ -156,7 +156,7 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
     if (currentLocation is StatefulLocation) {
       /// Pop inside the stateful child location as long as that's possible.
       /// Else we will pop the whole route.
-      if (currentLocation.state.currentRouterDelegate.currentConfiguration
+      if (currentLocation.state.currentRouterDelegate.currentConfiguration!
               .locations.length >
           1) {
         return currentLocation.state.reset();

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -138,6 +138,7 @@ class DuckRouter implements RouterConfig<LocationStack> {
         );
       }
 
+      currentStack.locations.forEach(configuration.removeLocation);
       currentStack.locations.clear();
       return routeInformationProvider.navigate<T>(
         to,
@@ -155,6 +156,7 @@ class DuckRouter implements RouterConfig<LocationStack> {
     }
 
     if ((replace ?? false)) {
+      configuration.removeLocation(currentStack.locations.last);
       currentStack.locations.removeLast();
     }
 

--- a/duck_router/lib/src/shell.dart
+++ b/duck_router/lib/src/shell.dart
@@ -140,15 +140,19 @@ class DuckShellState extends State<DuckShell> {
     bool? replace,
     bool? clearStack,
   }) async {
+    final currentStack = _currentRouterDelegate.currentConfiguration;
+
     if (clearStack ?? false) {
-      currentRouterDelegate.currentConfiguration.locations.clear();
+      currentStack.locations.forEach(widget.configuration.removeLocation);
+      currentStack.locations.clear();
     } else if (replace ?? false) {
-      currentRouterDelegate.currentConfiguration.locations.removeLast();
+      widget.configuration.removeLocation(currentStack.locations.last);
+      currentStack.locations.removeLast();
     }
 
     return _informationProviders[_currentIndex].navigate<T>(
       to,
-      baseLocationStack: currentRouterDelegate.currentConfiguration,
+      baseLocationStack: currentStack,
     );
   }
 
@@ -194,7 +198,11 @@ class DuckShellState extends State<DuckShell> {
     });
   }
 
-  RouterDelegate get currentRouterDelegate => _routerDelegates[_currentIndex];
+  RouterDelegate<LocationStack> get currentRouterDelegate =>
+      _routerDelegates[_currentIndex];
+
+  _NestedRouterDelegate get _currentRouterDelegate =>
+      currentRouterDelegate as _NestedRouterDelegate;
 }
 
 typedef _NewPathCallback = void Function(LocationStack configuration);


### PR DESCRIPTION
## Description

This is a **possible** fix for #47.

It updates the replace & clearStack mechanism, to also complete the cached Completer when the location is removed from the LocationStack, as well as removing the path from the dynamic path registry.

Changed user behavior: when awaiting the navigation result of a page B, and this page is replaced by page C, the Future will now complete when the page C is pushed, without a result value. This will as well happen when a navigation result is awaited, but the stack is cleared. Previously, these Futures would be kept open until the app session was finished.

**Open question**: right now the result in this scenario will always be null. Do we want to update the navigate method API to include a replaceResult or something? While it might make sense for a replace, it would only raise more issues I think when used with the clearStack parameter. It might as well create confusion for the user as to when this result is being used. Lastly, it would probably raise some concerns about separation of concerns, if page A needs to know the default response of page B. So I do have an opinion about this, but maybe someone else has more ideas where it might be useful to add it.

## Related Issues

#47 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.
