### PR TITLE
feat: allow awaiting a page that gets replaced

### DIFF
--- a/duck_router/lib/src/configuration.dart
+++ b/duck_router/lib/src/configuration.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:duck_router/src/exception.dart';
 import 'package:flutter/material.dart';
 import 'package:duck_router/src/interceptor.dart';
 import 'package:duck_router/src/location.dart';
@@ -101,7 +102,17 @@ class DuckRouterConfiguration {
 
   /// Removes a location from the current dynamic directory of locations.
   void removeLocation<T>(Location location, [FutureOr<T>? value]) {
-    _routeMapping[location.path]?.completer?.complete(value);
+    final completer = _routeMapping[location.path]?.completer;
+    try {
+      completer?.complete(value);
+    } on TypeError catch (_) {
+      completer?.completeError(const DuckRouterException(
+          'Trying to return result with pop that does not match the '
+          'awaited type. \n'
+          'Check the type of the result you are returning. This can also happen '
+          'if you have replaced a location with another location, and the new '
+          'location returns a different type.'));
+    }
     _routeMapping.remove(location.path);
   }
 }

--- a/duck_router/lib/src/configuration.dart
+++ b/duck_router/lib/src/configuration.dart
@@ -67,10 +67,27 @@ class DuckRouterConfiguration {
 
   /// Adds a [Location] to the current dynamic directory of locations, so
   /// that we can find it back later, e.g. upon state restoration.
-  void addLocation<T>(Location location, {Completer<T>? completer}) {
+  void addLocation<T>(
+    Location location, {
+    Completer<T>? completer,
+
+    /// If this location replaced another, the location needs to be
+    /// provided here so that we can redirect the completer.
+    Location? replaced,
+  }) {
     if (_routeMapping.containsKey(location.path)) {
       return;
     }
+
+    if (replaced != null) {
+      _routeMapping[location.path] = LocationMatch(
+        location: location,
+        completer: _routeMapping[replaced.path]?.completer,
+      );
+      _routeMapping.remove(replaced.path);
+      return;
+    }
+
     _routeMapping[location.path] = LocationMatch(
       location: location,
       completer: completer,

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -120,6 +120,17 @@ class DuckRouter implements RouterConfig<LocationStack> {
   ///
   /// If [clearStack] is set, the current stack will be cleared before navigating.
   /// [clearStack] will take precedence over [replace].
+  ///
+  /// You can await [navigate] to pass back results from thhe new location.
+  /// This can create complicated scenarios when used in combination with
+  /// [replace]. The behavior defined as follows:
+  ///
+  /// - Location A navigates to and awaits Location B
+  /// - Location B is replaced by Location C
+  /// - Location C pops, with a result.
+  ///
+  /// This result will still be passed to Location A. Be mindful that this
+  /// result should be of the same type as the result of Location B.
   Future<T?> navigate<T extends Object?>({
     required Location to,
     bool root = false,

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -128,6 +128,7 @@ class DuckRouter implements RouterConfig<LocationStack> {
   }) {
     final currentStack = routerDelegate.currentConfiguration;
     final currentRootLocation = currentStack.locations.last;
+    Location? replaced;
 
     if (clearStack ?? false) {
       if (currentRootLocation is StatefulLocation && !root) {
@@ -154,13 +155,14 @@ class DuckRouter implements RouterConfig<LocationStack> {
       return currentRootLocation.state.navigate(to, replace: replace);
     }
 
-    if ((replace ?? false)) {
-      currentStack.locations.removeLast();
+    if (replace ?? false) {
+      replaced = currentStack.locations.removeLast();
     }
 
     return routeInformationProvider.navigate<T>(
       to,
       baseLocationStack: currentStack,
+      replaced: replaced,
     );
   }
 

--- a/duck_router/lib/src/parser.dart
+++ b/duck_router/lib/src/parser.dart
@@ -52,6 +52,7 @@ class DuckInformationParser extends RouteInformationParser<LocationStack> {
       state.location,
       currentStack,
       completer: state.completer,
+      replaced: state.replaced,
     );
   }
 
@@ -70,6 +71,7 @@ class DuckInformationParser extends RouteInformationParser<LocationStack> {
     Location to,
     List<Location> currentStack, {
     Completer? completer,
+    Location? replaced,
   }) {
     for (final i in _configuration.interceptors ?? <LocationInterceptor>[]) {
       final result = i.execute(
@@ -77,7 +79,11 @@ class DuckInformationParser extends RouteInformationParser<LocationStack> {
         currentStack.lastOrNull,
       );
       if (result != null) {
-        _configuration.addLocation(result, completer: completer);
+        _configuration.addLocation(
+          result,
+          completer: completer,
+          replaced: replaced,
+        );
         _configuration.onNavigate?.call(result);
         if (i.pushesOnTop) {
           return LocationStack(locations: [...currentStack, to, result]);
@@ -89,7 +95,7 @@ class DuckInformationParser extends RouteInformationParser<LocationStack> {
       }
     }
 
-    _configuration.addLocation(to, completer: completer);
+    _configuration.addLocation(to, completer: completer, replaced: replaced);
     _configuration.onNavigate?.call(to);
     return LocationStack(locations: [...currentStack, to]);
   }

--- a/duck_router/lib/src/provider.dart
+++ b/duck_router/lib/src/provider.dart
@@ -41,6 +41,7 @@ class DuckInformationProvider extends RouteInformationProvider
   Future<T?> navigate<T>(
     Location location, {
     required LocationStack baseLocationStack,
+    Location? replaced,
   }) async {
     // This [Completer] is used for later on, when the page is popped,
     // returning a result.
@@ -61,6 +62,7 @@ class DuckInformationProvider extends RouteInformationProvider
         location: location,
         baseLocationStack: baseLocationStack,
         completer: completer,
+        replaced: replaced,
       ),
     );
     notifyListeners();

--- a/duck_router/lib/src/state.dart
+++ b/duck_router/lib/src/state.dart
@@ -11,6 +11,7 @@ class LocationState<T> {
     required this.location,
     required this.baseLocationStack,
     this.completer,
+    this.replaced,
   });
 
   /// The current location.
@@ -22,4 +23,7 @@ class LocationState<T> {
   /// The completer for the current location. When the location is popped,
   /// this completer should be completed.
   final Completer<T?>? completer;
+
+  /// The [Location] that this location is replacing.
+  final Location? replaced;
 }

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -255,6 +255,39 @@ void main() {
       expect(result, equals(1));
     });
 
+    /// Screen A --- navigates to and waits for result of ---> Screen B
+    /// Screen B --- navigates to with replace:true ---> Screen C
+    /// Screen C --- pops to ---> Screen A
+    testWidgets('can await navigate that gets replaced', (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+      );
+
+      final router = await createRouter(config, tester);
+      final locations = router.routerDelegate.currentConfiguration;
+      expect(locations.uri.path, '/home');
+
+      int result = 0;
+      router
+          .navigate<int>(
+        to: Page1Location(),
+      )
+          .then((value) {
+        return result = value!;
+      });
+      await tester.pumpAndSettle();
+      expect(find.byType(Page1Screen), findsOneWidget);
+
+      router.navigate(to: Page2Location(), replace: true);
+      await tester.pumpAndSettle();
+      expect(find.byType(Page2Screen), findsOneWidget);
+
+      router.pop(1);
+      await tester.pumpAndSettle();
+
+      expect(result, equals(1));
+    });
+
     testWidgets('can navigate to and from locations with arguments',
         (tester) async {
       final config = DuckRouterConfiguration(

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -288,6 +288,71 @@ void main() {
       expect(result, equals(1));
     });
 
+    testWidgets(
+        'throws error if trying to return different type result in location that replaces another',
+        (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+      );
+
+      final router = await createRouter(config, tester);
+      final locations = router.routerDelegate.currentConfiguration;
+      expect(locations.uri.path, '/home');
+
+      int _ = 0;
+      Exception? exception;
+      router
+          .navigate<int>(
+        to: Page1Location(),
+      )
+          .then((value) {
+        return _ = value!;
+      }).catchError((e) {
+        exception = e;
+        return 0;
+      });
+      await tester.pumpAndSettle();
+      expect(find.byType(Page1Screen), findsOneWidget);
+
+      router.navigate(to: Page2Location(), replace: true);
+      await tester.pumpAndSettle();
+      expect(find.byType(Page2Screen), findsOneWidget);
+
+      router.pop('different type than int');
+      await tester.pumpAndSettle();
+      expect(exception, isA<DuckRouterException>());
+    });
+
+    testWidgets('Can return null when a page replacing a page is being awaited',
+        (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+      );
+
+      final router = await createRouter(config, tester);
+      final locations = router.routerDelegate.currentConfiguration;
+      expect(locations.uri.path, '/home');
+
+      int result = 0;
+      router
+          .navigate<int>(
+        to: Page1Location(),
+      )
+          .then((value) {
+        return result = value ?? 1;
+      });
+      await tester.pumpAndSettle();
+      expect(find.byType(Page1Screen), findsOneWidget);
+
+      router.navigate(to: Page2Location(), replace: true);
+      await tester.pumpAndSettle();
+      expect(find.byType(Page2Screen), findsOneWidget);
+
+      router.pop();
+      await tester.pumpAndSettle();
+      expect(result, equals(1));
+    });
+
     testWidgets('can navigate to and from locations with arguments',
         (tester) async {
       final config = DuckRouterConfiguration(


### PR DESCRIPTION
## Description

When we navigate to a page and await its result, and that page gets replaced, the following pop is no longer listened to.  This PR implements behaviour where popping from a page that replaced another, will still trigger the original `await navigate`. It does so by creating a new mapping between the new incoming location (the one that replaces) and the completer of the original location when replacing.

## Related Issues

#47 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
