### PR TITLE
feat: allow popping root via popRoot

### DIFF
--- a/duck_router/lib/src/delegate.dart
+++ b/duck_router/lib/src/delegate.dart
@@ -94,10 +94,10 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
   }
 
   /// Pops the top location on the routing stack
-  void pop<T extends Object?>([T? result]) {
+  void pop<T extends Object?>([T? result, bool root = false]) {
     final currentLocation = currentConfiguration.locations.last;
 
-    if (currentLocation is StatefulLocation) {
+    if (currentLocation is StatefulLocation && !root) {
       /// Pop inside the stateful child location as long as that's possible.
       /// Else we will pop the whole route.
       if (currentLocation.state.currentRouterDelegate.currentConfiguration

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -185,6 +185,10 @@ class DuckRouter implements RouterConfig<LocationStack> {
     routerDelegate.pop<T>(result);
   }
 
+  void popRoot<T extends Object?>([T? result]) {
+    routerDelegate.pop<T>(result, true);
+  }
+
   void popUntil(LocationPredicate predicate) {
     routerDelegate.popUntil(predicate);
   }

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -652,6 +652,36 @@ void main() {
       expect(router.pop, throwsException);
     });
 
+    testWidgets('can pop the root', (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+      );
+
+      final router = await createRouter(config, tester);
+      var locations = router.routerDelegate.currentConfiguration;
+      expect(locations.uri.path, '/home');
+
+      router.navigate(to: RootLocation());
+      await tester.pumpAndSettle();
+
+      locations = router.routerDelegate.currentConfiguration;
+      expect(locations.uri.path, '/home/root');
+
+      router.navigate(to: Page1Location());
+      await tester.pumpAndSettle();
+
+      final locations2 = router.routerDelegate.currentConfiguration;
+      final statefulLocation = locations2.locations.last as StatefulLocation;
+      final child =
+          statefulLocation.state.currentRouterDelegate.currentConfiguration;
+      expect(child.uri.path, '/child1/page1');
+      expect(find.byType(Page1Screen), findsOneWidget);
+
+      router.popRoot();
+      locations = router.routerDelegate.currentConfiguration;
+      expect(locations.uri.path, '/home');
+    });
+
     testWidgets('can clear stack in nested locations', (tester) async {
       final config = DuckRouterConfiguration(
         initialLocation: RootLocation(),


### PR DESCRIPTION
## Description

Introduce a `popRoot` which allows the user to pop the root location even when there are numerous locations being hosted by it. Currently, you would have to pop all those locations first.

## Related Issues

Closes #52

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
