### PR TITLE
fix: throw exception to listeners if clearStack is used

### DIFF
--- a/duck_router/lib/src/configuration.dart
+++ b/duck_router/lib/src/configuration.dart
@@ -95,6 +95,23 @@ class DuckRouterConfiguration {
     );
   }
 
+  /// Clears a location from the current dynamic directory of locations, so
+  /// that we close any potential awaiters.
+  void clearLocation(Location location) {
+    final completer = _routeMapping[location.path]?.completer;
+
+    // If future does not have a listener, it will be considered an uncaught
+    // error. Thus, we need to handle the error and ignore it. User
+    // will still receive the error via the completer if they are listening.
+    completer?.future.catchError((e, s) {
+      // Do nothing, user has received error.
+    });
+    completer?.completeError(const DuckRouterException(
+      'Could not return a result from this location, it was cleared from the stack.',
+    ));
+    _routeMapping.remove(location.path);
+  }
+
   /// Returns the [LocationMatch] for the given path.
   LocationMatch? findLocation(String path) {
     return _routeMapping[path];

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -131,6 +131,9 @@ class DuckRouter implements RouterConfig<LocationStack> {
   ///
   /// This result will still be passed to Location A. Be mindful that this
   /// result should be of the same type as the result of Location B.
+  ///
+  /// If the awaited location is cleared using [clearStack], an error will be
+  /// thrown.
   Future<T?> navigate<T extends Object?>({
     required Location to,
     bool root = false,

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -150,7 +150,11 @@ class DuckRouter implements RouterConfig<LocationStack> {
         );
       }
 
+      for (final l in currentStack.locations) {
+        configuration.clearLocation(l);
+      }
       currentStack.locations.clear();
+
       return routeInformationProvider.navigate<T>(
         to,
         baseLocationStack: currentStack,

--- a/duck_router/lib/src/shell.dart
+++ b/duck_router/lib/src/shell.dart
@@ -141,6 +141,9 @@ class DuckShellState extends State<DuckShell> {
     bool? clearStack,
   }) async {
     if (clearStack ?? false) {
+      for (final l in currentRouterDelegate.currentConfiguration.locations) {
+        widget.configuration.clearLocation(l);
+      }
       currentRouterDelegate.currentConfiguration.locations.clear();
     } else if (replace ?? false) {
       currentRouterDelegate.currentConfiguration.locations.removeLast();

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -353,6 +353,39 @@ void main() {
       expect(result, equals(1));
     });
 
+    testWidgets('can await navigate that gets cleared via clearStack',
+        (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+      );
+
+      final router = await createRouter(config, tester);
+      final locations = router.routerDelegate.currentConfiguration;
+      expect(locations.uri.path, '/home');
+
+      int result = 0;
+      Exception? error;
+      router
+          .navigate<int>(
+        to: Page1Location(),
+      )
+          .then((value) {
+        return result = 1;
+      }).catchError((e) {
+        error = e;
+        return 2;
+      });
+      await tester.pumpAndSettle();
+      expect(find.byType(Page1Screen), findsOneWidget);
+
+      router.navigate(to: Page2Location(), clearStack: true);
+      await tester.pumpAndSettle();
+      expect(find.byType(Page2Screen), findsOneWidget);
+
+      expect(result, equals(0));
+      expect(error, TypeMatcher<DuckRouterException>());
+    });
+
     testWidgets('can navigate to and from locations with arguments',
         (tester) async {
       final config = DuckRouterConfiguration(
@@ -945,6 +978,39 @@ void main() {
       // Now we should start seeing an error because we're trying to pop
       // the root.
       expect(router.pop, throwsException);
+    });
+
+    testWidgets('can await navigate that gets cleared via clearStack',
+        (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: RootLocation(),
+      );
+
+      final router = await createRouter(config, tester);
+      final locations = router.routerDelegate.currentConfiguration;
+      expect(locations.uri.path, '/root');
+
+      int result = 0;
+      Exception? error;
+      router
+          .navigate<int>(
+        to: Page1Location(),
+      )
+          .then((value) {
+        return result = 1;
+      }).catchError((e) {
+        error = e;
+        return 2;
+      });
+      await tester.pumpAndSettle();
+      expect(find.byType(Page1Screen), findsOneWidget);
+
+      router.navigate(to: Page2Location(), clearStack: true);
+      await tester.pumpAndSettle();
+      expect(find.byType(Page2Screen), findsOneWidget);
+
+      expect(result, equals(0));
+      expect(error, TypeMatcher<DuckRouterException>());
     });
 
     group('Custom', () {


### PR DESCRIPTION
## Description

Scenario:

- Be on page A
- Navigate to page B, and await the result
- Navigate to page C, and clearStack = true

Page A will forever wait for a result.

This PR fixes this scenario. Page A will now receive an exception. 

Open for feedback on whether this should be seen as a breaking change. It has the potential to surface issues in apps.

## Related Issues

Fixes #51 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
