### PR TITLE
feat!: flow locations

### DIFF
--- a/duck_router/doc/stateful-navigation.md
+++ b/duck_router/doc/stateful-navigation.md
@@ -73,7 +73,7 @@ DuckRouter.of(context).navigate(to: const DetailLocation(), root: true);
 
 ## Bottom sheet
 
-This example shows how one might implement a bottom sheet containing a login/registration flow. It uses the [modal_bottom_sheet](https://pub.dev/packages/modal_bottom_sheet) package to accomplish that. This example combines usage of a [StatefulLocation] with custom pages, see also [Custom Pages](https://pub.dev/documentation/duck_router/latest/topics/Custom-pages-topic.html).
+This example shows how one might implement a bottom sheet containing a login/registration flow. It uses the [modal_bottom_sheet](https://pub.dev/packages/modal_bottom_sheet) package to accomplish that. To achieve cases like these, [DuckRouter] provides the convenience class [FlowLocation], a wrapper around [StatefulLocation]. This example combines usage of a [FlowLocation] with custom pages, see also [Custom Pages](https://pub.dev/documentation/duck_router/latest/topics/Custom-pages-topic.html).
 
 ```dart
 class SheetPage<T> extends DuckPage<T> {
@@ -158,22 +158,17 @@ Your actual flow would then look like this:
 
 ```dart
 
-class LoginFlowLocation extends StatefulLocation {
-  @override
-  LocationPageBuilder? get pageBuilder => (context) => SheetPage(
-        builder: builder,
-      );
-
-  @override
-  StatefulLocationBuilder get childBuilder => (context, shell) => shell;
-
-  @override
-  List<Location> get children => [
-        EmailLocation(),
-      ];
-
+class LoginFlowLocation extends FlowLocation {
   @override
   String get path => 'login-flow';
+
+  @override
+  Location get start => EmailLocation();
+
+  @override
+  LocationPageBuilder? get containerBuilder => (context) => SheetPage(
+        builder: builder,
+      );
 }
 ```
 

--- a/duck_router/doc/stateful-navigation.md
+++ b/duck_router/doc/stateful-navigation.md
@@ -168,7 +168,7 @@ class LoginFlowLocation extends FlowLocation {
   Location get start => EmailLocation();
 
   @override
-  StatefulLocationPageBuilder? get containerBuilder => (context) => SheetPage(
+  StatefulLocationPageBuilder? get containerBuilder => (context, builder) => SheetPage(
         builder: builder,
       );
 }

--- a/duck_router/doc/stateful-navigation.md
+++ b/duck_router/doc/stateful-navigation.md
@@ -4,7 +4,9 @@ Sometimes you want to have a separate navigation stack. For example:
 - A bottom sheet, or any other flow-like navigation, that allows users to go forward and backward.
 - Cases where you want to have a wrapper element around a set of routes
 
-See below for examples of such flows.
+`StatefulLocation` is an interface that tries to simplify the creation of these patterns, while still being flexible. For simple flows, we provide a convenience class `FlowLocation`.
+
+Below we provide examples of how to implement common use cases.
 
 ## Bottom bar
 
@@ -166,7 +168,7 @@ class LoginFlowLocation extends FlowLocation {
   Location get start => EmailLocation();
 
   @override
-  LocationPageBuilder? get containerBuilder => (context) => SheetPage(
+  StatefulLocationPageBuilder? get containerBuilder => (context) => SheetPage(
         builder: builder,
       );
 }

--- a/duck_router/lib/src/location.dart
+++ b/duck_router/lib/src/location.dart
@@ -216,11 +216,6 @@ abstract class StatefulLocation extends Location {
   /// modal.
   StatefulLocationBuilder get childBuilder;
 
-  @nonVirtual
-  @override
-  LocationPageBuilder? get pageBuilder =>
-      containerBuilder != null ? (c) => containerBuilder!(c, builder) : null;
-
   /// The builder for the container around all children. For example,
   /// if you want to wrap each child in a modal via a [DuckPage].
   ///
@@ -241,6 +236,11 @@ abstract class StatefulLocation extends Location {
   /// The state of the [DuckShell] for this location.
   @nonVirtual
   DuckShellState get state => _key.currentState!;
+
+  @nonVirtual
+  @override
+  LocationPageBuilder? get pageBuilder =>
+      containerBuilder != null ? (c) => containerBuilder!(c, builder) : null;
 
   @visibleForOverriding
   @nonVirtual

--- a/duck_router/lib/src/location.dart
+++ b/duck_router/lib/src/location.dart
@@ -108,10 +108,18 @@ typedef LocationBuilder = Widget Function(BuildContext context);
 /// ```
 ///
 /// See also:
-/// * [LocationBuilder] for a simpler builder that returns a [Widget].
-/// * [DuckPage] for the page you must override.
+/// - [LocationBuilder] for a simpler builder that returns a [Widget].
+/// - [DuckPage] for the page you must override.
+/// - [StatefulLocation] for a location that maintains its own state, such as
+/// for a bottom navigation bar.
+/// - [FlowLocation] for a simplified version of [StatefulLocation] for flows.
 typedef LocationPageBuilder = DuckPage<dynamic> Function(
   BuildContext context,
+);
+
+typedef StatefulLocationPageBuilder = DuckPage<dynamic> Function(
+  BuildContext context,
+  LocationBuilder builder,
 );
 
 /// {@template location}
@@ -120,6 +128,7 @@ typedef LocationPageBuilder = DuckPage<dynamic> Function(
 /// See also:
 /// - [StatefulLocation] for a location that maintains its own state, such as
 /// for a bottom navigation bar.
+/// - [FlowLocation] for a simplified version of [StatefulLocation] for flows.
 /// - [LocationPageBuilder] for a builder that allows you to build a custom
 /// [Page], e.g. for custom transitions.
 /// {@endtemplate}
@@ -209,14 +218,25 @@ abstract class StatefulLocation extends Location {
 
   @nonVirtual
   @override
-  LocationPageBuilder? get pageBuilder => containerBuilder;
+  LocationPageBuilder? get pageBuilder =>
+      containerBuilder != null ? (c) => containerBuilder!(c, builder) : null;
 
   /// The builder for the container around all children. For example,
   /// if you want to wrap each child in a modal via a [DuckPage].
   ///
+  /// Example:
+  /// ```dart
+  /// @override
+  /// StatefulLocationPageBuilder get containerBuilder => (context, builder) =>
+  ///   ModalPage( // this is a [DuckPage]
+  ///     builder: builder
+  ///   ),
+  /// );
+  /// ```
+  ///
   /// See also:
   /// - [childBuilder], the builder for the pages themselves.
-  LocationPageBuilder? get containerBuilder => null;
+  StatefulLocationPageBuilder? get containerBuilder => null;
 
   /// The state of the [DuckShell] for this location.
   @nonVirtual
@@ -252,7 +272,7 @@ abstract class StatefulLocation extends Location {
 abstract class FlowLocation extends StatefulLocation {
   @factory
   @override
-  LocationPageBuilder? get containerBuilder;
+  StatefulLocationPageBuilder? get containerBuilder;
 
   @override
   StatefulLocationBuilder get childBuilder => (_, shell) => shell;

--- a/duck_router/lib/src/location.dart
+++ b/duck_router/lib/src/location.dart
@@ -168,7 +168,7 @@ typedef StatefulLocationBuilder = Widget Function(
 /// A location that maintains its own state with the use of a [Navigator]. A
 /// [StatefulLocation] hosts its [children] in individually separate navigation
 /// stacks. Specify how the children are built using [childBuilder]. Customize
-/// each child stack with [containerBuilder].
+/// the wrapping container all children live in via [containerBuilder].
 ///
 /// See also:
 /// - [FlowLocation], a convenience class for creating a [StatefulLocation] in

--- a/duck_router/lib/src/location.dart
+++ b/duck_router/lib/src/location.dart
@@ -242,6 +242,7 @@ abstract class StatefulLocation extends Location {
   @nonVirtual
   DuckShellState get state => _key.currentState!;
 
+  @visibleForOverriding
   @nonVirtual
   @override
   LocationBuilder get builder => (context) {

--- a/duck_router/lib/src/pages/page.dart
+++ b/duck_router/lib/src/pages/page.dart
@@ -118,6 +118,16 @@ class DuckPage<T> {
   ///
   /// This transition will wrap the [child] widget.
   ///
+  /// Example:
+  /// ```dart
+  /// @override
+  /// LocationPageBuilder get pageBuilder => (context) => DuckPage(
+  ///      child: HomeScreen(),
+  ///      transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+  ///          FadeTransition(opacity: animation, child: child),
+  ///    );
+  /// ```
+  ///
   /// See also:
   /// - [ModalRoute.buildTransitions] for more information on how to use this.
   final TransitionBuilder? transitionsBuilder;

--- a/duck_router/pubspec.yaml
+++ b/duck_router/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   equatable: ^2.0.5
   flutter:
     sdk: flutter
+  meta: ^1.15.0
 
 dev_dependencies:
   flutter_test:

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -1044,6 +1044,43 @@ void main() {
         expect(find.byType(Page1Screen), findsOneWidget);
       });
     });
+
+    group('FlowLocation', () {
+      testWidgets('can navigate to page', (tester) async {
+        final config = DuckRouterConfiguration(
+          initialLocation: HomeLocation(),
+        );
+
+        final router = await createRouter(config, tester);
+        await tester.pumpAndSettle();
+        router.navigate(to: TestFlowLocation());
+        await tester.pumpAndSettle();
+        expect(find.byType(Page1Screen), findsOneWidget);
+        final locations = router.routerDelegate.currentConfiguration;
+        expect(locations.uri.path, '/home/flow');
+      });
+
+      testWidgets('can navigate to another page from start', (tester) async {
+        final config = DuckRouterConfiguration(
+          initialLocation: HomeLocation(),
+        );
+
+        final router = await createRouter(config, tester);
+        await tester.pumpAndSettle();
+        router.navigate(to: TestFlowLocation());
+        await tester.pumpAndSettle();
+        expect(find.byType(Page1Screen), findsOneWidget);
+        router.navigate(to: Page2Location());
+        await tester.pumpAndSettle();
+        expect(find.byType(Page2Screen), findsOneWidget);
+        final locations = router.routerDelegate.currentConfiguration;
+        expect(locations.uri.path, '/home/flow');
+        final flowLocation = locations.locations.last as FlowLocation;
+        final innerLocations =
+            flowLocation.state.currentRouterDelegate.currentConfiguration;
+        expect(innerLocations.uri.path, '/page1/page2');
+      });
+    });
   });
 
   group('Deeplinking', () {

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -1080,6 +1080,18 @@ void main() {
             flowLocation.state.currentRouterDelegate.currentConfiguration;
         expect(innerLocations.uri.path, '/page1/page2');
       });
+
+      testWidgets('can render with container', (tester) async {
+        final config = DuckRouterConfiguration(
+          initialLocation: HomeLocation(),
+        );
+
+        final router = await createRouter(config, tester);
+        await tester.pumpAndSettle();
+        router.navigate(to: TestFlowLocationWithContainer());
+        await tester.pumpAndSettle();
+        expect(find.byType(Page1Screen), findsOneWidget);
+      });
     });
   });
 

--- a/duck_router/test/src/test_helpers.dart
+++ b/duck_router/test/src/test_helpers.dart
@@ -314,6 +314,17 @@ class CustomScreen extends StatelessWidget {
   Widget build(BuildContext context) => const Placeholder();
 }
 
+class TestFlowLocation extends FlowLocation {
+  @override
+  String get path => 'flow';
+
+  @override
+  Location get start => Page1Location();
+
+  @override
+  LocationPageBuilder? get containerBuilder => null;
+}
+
 /// This is a faulty custom implementation because it uses the custom constructor
 /// without overriding `createRoute`.
 class FaultyCustomPage<T> extends DuckPage<T> {

--- a/duck_router/test/src/test_helpers.dart
+++ b/duck_router/test/src/test_helpers.dart
@@ -335,7 +335,7 @@ class TestFlowLocationWithContainer extends FlowLocation {
   @override
   StatefulLocationPageBuilder? get containerBuilder => (c, b) {
         return DuckPage(
-            child: Page1Screen(),
+            child: b(c),
             transitionsBuilder: (c, a1, a2, child) =>
                 FadeTransition(opacity: a1, child: child));
       };

--- a/duck_router/test/src/test_helpers.dart
+++ b/duck_router/test/src/test_helpers.dart
@@ -322,7 +322,23 @@ class TestFlowLocation extends FlowLocation {
   Location get start => Page1Location();
 
   @override
-  LocationPageBuilder? get containerBuilder => null;
+  StatefulLocationPageBuilder? get containerBuilder => null;
+}
+
+class TestFlowLocationWithContainer extends FlowLocation {
+  @override
+  String get path => 'flow';
+
+  @override
+  Location get start => Page1Location();
+
+  @override
+  StatefulLocationPageBuilder? get containerBuilder => (c, b) {
+        return DuckPage(
+            child: Page1Screen(),
+            transitionsBuilder: (c, a1, a2, child) =>
+                FadeTransition(opacity: a1, child: child));
+      };
 }
 
 /// This is a faulty custom implementation because it uses the custom constructor


### PR DESCRIPTION
## Description

This PR tackles the difficulty in creating flows, see also #56, and in general some of the complexity in creating nested locations. I tackled this issue by taking an approach of:

- Limiting the methods that can be overridden to only those that can actually be useful, which simplifies the interface. They are `meta` tags, so consumer can ignore the warnings if really needed. Our intention of course is for that not to be needed.
- Renaming methods where useful to make the interface easier to use. I have renamed `pageBuilder` to `containerBuilder`, which I think is much easier to understand. It means you now have a `childBuilder` and a `containerBuilder`. The former builds every child, the latter builds the container around the whole stack. I considered `stackBuilder` for a bit for I feel that's a more niche term.
- I made the observation that for the use case of flows, `StatefulLocation`s are useful (and needed), but offer too much complexity. I have created a convenience class called `FlowLocation` which I believe makes creating a flow, with or without wrapping layout such as sheets, very easy. It means consumer no longer need to worry about `children` (why does it only have one child?), etc.

See also the updated documentation. Some renaming thoughts:

- A potential follow-up could be renaming `popRoot` and `root` to `close` and `start`? You have a `FlowLocation` and you call close on it, seems obvious what it does. Only concern would be confusion with `pop`. Maybe I'm making it too complicated there.

## Related Issues

Fixes #56 

Also related: #11, #21

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [X] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.

## Migration guide

Replace `pageBuilder` with `containerBuilder`, like so:

Before:

```dart
  @override
  LocationPageBuilder? get pageBuilder => (context) => SheetPage(
        builder: builder,
      );
```

After:

```dart
 @override
  StatefulLocationPageBuilder? get containerBuilder => (context, builder) => SheetPage(
        builder: builder,
      );
```

You might find warnings related to usage of `builder` and `pageBuilder`. All these usages should be replaced by `containerBuilder`.
