### PR TITLE
refactor!: tighten up classes

### DIFF
--- a/duck_router/lib/src/location.dart
+++ b/duck_router/lib/src/location.dart
@@ -10,7 +10,7 @@ import 'package:meta/meta.dart';
 /// {@template location_stack}
 /// A stack of locations.
 /// {@endtemplate}
-class LocationStack extends Equatable {
+final class LocationStack extends Equatable {
   /// {@macro location_stack}
   const LocationStack({
     required this.locations,
@@ -288,7 +288,8 @@ abstract class FlowLocation extends StatefulLocation {
 /// {@template location_list_codec}
 /// A [Codec] for encoding and decoding a [LocationStack].
 /// {@endtemplate}
-class LocationStackCodec extends Codec<LocationStack, Map<Object?, Object?>> {
+final class LocationStackCodec
+    extends Codec<LocationStack, Map<Object?, Object?>> {
   /// {@macro location_list_codec}
   LocationStackCodec({
     required DuckRouterConfiguration configuration,

--- a/duck_router/lib/src/state.dart
+++ b/duck_router/lib/src/state.dart
@@ -5,7 +5,7 @@ import 'package:duck_router/src/location.dart';
 /// {@template location_state}
 /// A state object that maintains state for the current location in the router.
 /// {@endtemplate}
-class LocationState<T> {
+final class LocationState<T> {
   /// {@macro location_state}
   LocationState({
     required this.location,


### PR DESCRIPTION
## Description

Tighten up the API by using the new dart class modifiers to disable usage outside of the package.

## Related Issues

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [X] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.
