### PR TITLE
refactor: deprecate `popRoot` for `exit`

### DIFF
--- a/duck_router/doc/stateful-navigation.md
+++ b/duck_router/doc/stateful-navigation.md
@@ -183,5 +183,5 @@ DuckRouter.of(context).navigate(to: const PasswordLocation());
 // Or go all the way back to the root:
 DuckRouter.of(context).root();
 // Or close the sheet entirely:
-DuckRouter.of(context).popRoot();
+DuckRouter.of(context).exit();
 ```

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -198,7 +198,8 @@ class DuckRouter implements RouterConfig<LocationStack> {
     routerDelegate.pop<T>(result, true);
   }
 
-  /// Close the current stack of routes.
+  /// Close the current stack of routes if in a [StatefulLocation] or
+  /// [FlowLocation], otherwise, pop.
   ///
   /// This is equivalent to calling [pop] until the root location is reached,
   /// in other words, it will immediately pop the root location.

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -193,7 +193,19 @@ class DuckRouter implements RouterConfig<LocationStack> {
   }
 
   /// Pop the root route off the current screen.
+  @Deprecated('Use exit instead')
   void popRoot<T extends Object?>([T? result]) {
+    routerDelegate.pop<T>(result, true);
+  }
+
+  /// Close the current stack of routes.
+  ///
+  /// This is equivalent to calling [pop] until the root location is reached,
+  /// in other words, it will immediately pop the root location.
+  ///
+  /// See also:
+  /// - [StatefulLocation] for creating an inner navigation stack.
+  void exit<T extends Object?>([T? result]) {
     routerDelegate.pop<T>(result, true);
   }
 

--- a/duck_router/lib/src/location.dart
+++ b/duck_router/lib/src/location.dart
@@ -267,8 +267,8 @@ abstract class StatefulLocation extends Location {
 /// optimised for common use cases.
 ///
 /// See also:
-/// - DuckRouter.exit, which allows you to pop the entire flow.
-/// - DuckRouter.root, which allows you to go back to the start of the flow.
+/// - [DuckRouter.exit], which allows you to pop the entire flow.
+/// - [DuckRouter.root], which allows you to go back to the start of the flow.
 ///
 abstract class FlowLocation extends StatefulLocation {
   @factory

--- a/duck_router/lib/src/location.dart
+++ b/duck_router/lib/src/location.dart
@@ -267,7 +267,7 @@ abstract class StatefulLocation extends Location {
 /// optimised for common use cases.
 ///
 /// See also:
-/// - DuckRouter.popRoot, which allows you to pop the entire flow.
+/// - DuckRouter.exit, which allows you to pop the entire flow.
 /// - DuckRouter.root, which allows you to go back to the start of the flow.
 ///
 abstract class FlowLocation extends StatefulLocation {

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -710,7 +710,7 @@ void main() {
       expect(child.uri.path, '/child1/page1');
       expect(find.byType(Page1Screen), findsOneWidget);
 
-      router.popRoot();
+      router.exit();
       locations = router.routerDelegate.currentConfiguration;
       expect(locations.uri.path, '/home');
     });


### PR DESCRIPTION
## Description

I do not find `popRoot` an intuitive name, it's not immediately obvious what its difference with `root` and `pop` is. Thus, introducing `exit`: instantly exit the current navigational stack if currently in a stateful location. See also: #57. I have implemented using deprecation to not break current usages.

## Related Issues

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is _not_ a breaking change.
