### PR TITLE
feat: expose DuckRouterException

### DIFF
--- a/duck_router/lib/duck_router.dart
+++ b/duck_router/lib/duck_router.dart
@@ -4,3 +4,4 @@ export 'src/location.dart';
 export 'src/duck_router.dart';
 export 'src/shell.dart';
 export 'src/pages/page.dart';
+export 'src/exception.dart';

--- a/duck_router/lib/src/delegate.dart
+++ b/duck_router/lib/src/delegate.dart
@@ -2,7 +2,6 @@ import 'package:collection/collection.dart';
 import 'package:duck_router/duck_router.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:duck_router/src/exception.dart';
 
 import 'navigator.dart';
 

--- a/duck_router/lib/src/location.dart
+++ b/duck_router/lib/src/location.dart
@@ -4,7 +4,6 @@ import 'package:duck_router/duck_router.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:duck_router/src/exception.dart';
 import 'package:meta/meta.dart';
 
 /// {@template location_stack}


### PR DESCRIPTION
## Description

I want to be able to catch `DuckRouterException`s, but they are not exposed. This exposes the Exception.

I think we should also maybe break down the different thrown exceptions into subclassed exceptions, or maybe an enum inside the `DuckRouterException`, to properly catch specific exceptions (I want to catch the exception that occurs when the clearstack is triggered). I see this as a separate PR, how would you tackle this?

## Related Issues

/

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
