### PR TITLE
refactor: reorganise thrown exceptions

### DIFF
--- a/duck_router/lib/src/configuration.dart
+++ b/duck_router/lib/src/configuration.dart
@@ -106,9 +106,7 @@ class DuckRouterConfiguration {
     completer?.future.catchError((e, s) {
       // Do nothing, user has received error.
     });
-    completer?.completeError(const DuckRouterException(
-      'Could not return a result from this location, it was cleared from the stack.',
-    ));
+    completer?.completeError(ClearStackException(location));
     _routeMapping.remove(location.path);
   }
 
@@ -123,12 +121,7 @@ class DuckRouterConfiguration {
     try {
       completer?.complete(value);
     } on TypeError catch (_) {
-      completer?.completeError(const DuckRouterException(
-          'Trying to return result with pop that does not match the '
-          'awaited type. \n'
-          'Check the type of the result you are returning. This can also happen '
-          'if you have replaced a location with another location, and the new '
-          'location returns a different type.'));
+      completer?.completeError(InvalidPopTypeException(location, value));
     }
     _routeMapping.remove(location.path);
   }

--- a/duck_router/lib/src/delegate.dart
+++ b/duck_router/lib/src/delegate.dart
@@ -111,7 +111,7 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
       state = navigatorKey.currentState;
     }
     if (currentConfiguration.locations.length == 1) {
-      throw const DuckRouterException('There is nothing to pop!');
+      throw const EmptyStackException();
     }
     state?.pop(result);
   }
@@ -135,8 +135,7 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
     final destination = currentConfiguration.locations
         .firstWhereOrNull((location) => predicate(location));
     if (destination == null) {
-      throw const DuckRouterException(
-          'Provided Location predicate does not match any Locations in current stack!');
+      throw const NoLocationMatchFoundException();
     }
 
     NavigatorState? state;

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -166,7 +166,7 @@ class DuckRouter implements RouterConfig<LocationStack> {
 
     if (!(replace ?? false) &&
         currentStack.locations.any((loc) => loc.path == to.path)) {
-      throw DuckRouterException('Cannot push duplicate route: ${to.path}');
+      throw DuplicateRouteException(to);
     }
 
     if (currentRootLocation is StatefulLocation && !root) {

--- a/duck_router/lib/src/exception.dart
+++ b/duck_router/lib/src/exception.dart
@@ -13,3 +13,50 @@ class DuckRouterException implements Exception {
   @override
   String toString() => 'RouterException: $message';
 }
+
+class ClearStackException extends DuckRouterException {
+  final Location location;
+
+  const ClearStackException(this.location)
+      : super(
+          'Could not return a result from this location, it was cleared from the stack.',
+        );
+}
+
+class InvalidPopTypeException extends DuckRouterException {
+  final Location location;
+  final Object? value;
+
+  const InvalidPopTypeException(this.location, this.value)
+      : super('Trying to return result with pop that does not match the '
+            'awaited type. \n'
+            'Check the type of the result you are returning. This can also happen '
+            'if you have replaced a location with another location, and the new '
+            'location returns a different type.');
+}
+
+class EmptyStackException extends DuckRouterException {
+  const EmptyStackException() : super('There is nothing to pop!');
+}
+
+class NoLocationMatchFoundException extends DuckRouterException {
+  const NoLocationMatchFoundException()
+      : super(
+            'Provided Location predicate does not match any Locations in current stack!');
+}
+
+class DuplicateRouteException extends DuckRouterException {
+  final Location location;
+
+  DuplicateRouteException(this.location)
+      : super('Cannot push duplicate route: ${location.path}');
+}
+
+class LocationStackDecoderException extends DuckRouterException {
+  const LocationStackDecoderException(super.message);
+}
+
+class MissingCreateRouteException extends DuckRouterException {
+  const MissingCreateRouteException()
+      : super('When using a custom DuckPage, you must override createRoute');
+}

--- a/duck_router/lib/src/location.dart
+++ b/duck_router/lib/src/location.dart
@@ -360,12 +360,12 @@ class _LocationStackDecoder
   Location _convertLocation(Map<Object?, Object?> input) {
     final path = input[LocationStackCodec._keyLocationPath] as String?;
     if (path == null) {
-      throw const DuckRouterException('Invalid path');
+      throw const LocationStackDecoderException('Invalid path');
     }
 
     final route = _configuration.findLocation(path);
     if (route == null) {
-      throw const DuckRouterException('Route not found');
+      throw const LocationStackDecoderException('Route not found');
     }
 
     return route.location;

--- a/duck_router/lib/src/pages/page.dart
+++ b/duck_router/lib/src/pages/page.dart
@@ -150,9 +150,7 @@ class DuckPage<T> {
     RouteSettings? settings,
   ) {
     if (child == null || transitionsBuilder == null) {
-      throw const DuckRouterException(
-        'When using a custom DuckPage, you must override createRoute',
-      );
+      throw const MissingCreateRouteException();
     }
     return null;
   }

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -321,7 +321,7 @@ void main() {
 
       router.pop('different type than int');
       await tester.pumpAndSettle();
-      expect(exception, isA<DuckRouterException>());
+      expect(exception, isA<InvalidPopTypeException>());
     });
 
     testWidgets('Can return null when a page replacing a page is being awaited',
@@ -384,7 +384,7 @@ void main() {
       expect(find.byType(Page2Screen), findsOneWidget);
 
       expect(result, equals(0));
-      expect(error, TypeMatcher<DuckRouterException>());
+      expect(error, TypeMatcher<ClearStackException>());
     });
 
     testWidgets('can navigate to and from locations with arguments',
@@ -515,11 +515,7 @@ void main() {
           page.createRoute(context, null);
           fail('Should have thrown an error');
         } catch (e) {
-          expect(e, isInstanceOf<DuckRouterException>());
-          expect(
-              e.toString(),
-              contains(
-                  'When using a custom DuckPage, you must override createRoute'));
+          expect(e, isInstanceOf<MissingCreateRouteException>());
         }
       });
     });
@@ -619,11 +615,7 @@ void main() {
       // Second navigation to the same path
       expect(
         () => router.navigate(to: HomeLocation()),
-        throwsA(isA<DuckRouterException>().having(
-          (e) => e.toString(),
-          'message',
-          contains('Cannot push duplicate route: home'),
-        )),
+        throwsA(isA<DuplicateRouteException>()),
       );
 
       await tester.pumpAndSettle();
@@ -1023,7 +1015,7 @@ void main() {
       expect(find.byType(Page2Screen), findsOneWidget);
 
       expect(result, equals(0));
-      expect(error, TypeMatcher<DuckRouterException>());
+      expect(error, TypeMatcher<ClearStackException>());
     });
 
     group('Custom', () {

--- a/duck_router/test/src/location_test.dart
+++ b/duck_router/test/src/location_test.dart
@@ -98,7 +98,8 @@ void main() {
       );
 
       final encoded = codec.encode(list);
-      expect(() => codec.decode(encoded), throwsA(isA<DuckRouterException>()));
+      expect(() => codec.decode(encoded),
+          throwsA(isA<LocationStackDecoderException>()));
     });
   });
 }


### PR DESCRIPTION
## Description

I wanted to catch specific exceptions thrown by DuckRouter (when the result can't be returned due to clearing the stack). This led me to an uncomfortable check on the exception message to see if this was the desired exception.

This change should make catching specific exceptions easier, with backwards compatibility.

## Related Issues

/

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
