### PR TITLE
fix: complete completer when replacing in shell

### DIFF
--- a/duck_router/lib/src/shell.dart
+++ b/duck_router/lib/src/shell.dart
@@ -137,18 +137,22 @@ class DuckShellState extends State<DuckShell> {
     bool? replace,
     bool? clearStack,
   }) async {
+    Location? replaced;
+
     if (clearStack ?? false) {
       for (final l in currentRouterDelegate.currentConfiguration.locations) {
         widget.configuration.clearLocation(l);
       }
       currentRouterDelegate.currentConfiguration.locations.clear();
     } else if (replace ?? false) {
-      currentRouterDelegate.currentConfiguration.locations.removeLast();
+      replaced =
+          currentRouterDelegate.currentConfiguration.locations.removeLast();
     }
 
     return _informationProviders[_currentIndex].navigate<T>(
       to,
       baseLocationStack: currentRouterDelegate.currentConfiguration,
+      replaced: replaced,
     );
   }
 

--- a/duck_router/test/src/test_helpers.dart
+++ b/duck_router/test/src/test_helpers.dart
@@ -118,6 +118,20 @@ class Page2Location extends Location {
   LocationBuilder get builder => (context) => const Page2Screen();
 }
 
+class Page3Screen extends DummyScreen {
+  const Page3Screen({super.key});
+}
+
+class Page3Location extends Location {
+  const Page3Location();
+
+  @override
+  String get path => 'page3';
+
+  @override
+  LocationBuilder get builder => (context) => const Page3Screen();
+}
+
 class LoginScreen extends DummyScreen {
   const LoginScreen({super.key});
 }


### PR DESCRIPTION
## Description

Similar to #47 , a navigation result is never returned when replacing the screen we are awaiting the result from. A fix was already implemented when this occurred in the root stack, but was missing when in a nested stack.

## Related Issues

#47 
#50 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
