### PR TITLE
feat: restoration of location arguments

### DIFF
--- a/duck_router/lib/src/configuration.dart
+++ b/duck_router/lib/src/configuration.dart
@@ -67,6 +67,7 @@ class DuckRouterConfiguration {
 
   final Map<String, LocationMatch> _routeMapping = {};
 
+  /// {@macro duck_restorer}
   final DuckRestorer? duckRestorer;
 
   /// Adds a [Location] to the current dynamic directory of locations, so
@@ -147,8 +148,10 @@ class LocationMatch<T> {
   final Completer<T>? completer;
 }
 
+/// {@template duck_restorer}
 /// A [DuckRestorer] allows restoration of [Location] objects upon e.g. an app
 /// restart.
+/// {@endtemplate}
 abstract class DuckRestorer {
   /// [fromJson] is called when the router is being restored from e.g. an app
   /// restart. In that case, the router will repeatedly call this method

--- a/duck_router/lib/src/configuration.dart
+++ b/duck_router/lib/src/configuration.dart
@@ -37,6 +37,7 @@ class DuckRouterConfiguration {
     this.onDeepLink,
     this.onNavigate,
     this.navigatorObserverBuilder,
+    this.duckRestorer,
   }) : rootNavigatorKey = rootNavigatorKey ?? GlobalKey<NavigatorState>();
 
   /// The list of locations that the user can route to
@@ -65,6 +66,8 @@ class DuckRouterConfiguration {
   final DuckRouterNavigatorObserverBuilder? navigatorObserverBuilder;
 
   final Map<String, LocationMatch> _routeMapping = {};
+
+  final DuckRestorer? duckRestorer;
 
   /// Adds a [Location] to the current dynamic directory of locations, so
   /// that we can find it back later, e.g. upon state restoration.
@@ -142,4 +145,26 @@ class LocationMatch<T> {
 
   final Location location;
   final Completer<T>? completer;
+}
+
+/// A [DuckRestorer] allows restoration of [Location] objects upon e.g. an app
+/// restart.
+abstract class DuckRestorer {
+  /// [fromJson] is called when the router is being restored from e.g. an app
+  /// restart. In that case, the router will repeatedly call this method
+  /// to re-create the state.
+  ///
+  /// Note: `path` and `arguments` correspond to [Location.path] and
+  /// [Location.toJson] respectively.
+  ///
+  /// See also:
+  /// - [toJson]: the inverse
+  Location? fromJson(String path, Map<String, dynamic> arguments);
+
+  /// [toJson] will be called when the router is saving itself for a later
+  /// restoration, e.g. on app restart.
+  ///
+  /// See also:
+  /// - [fromJson]: the inverse
+  Map<String, dynamic> toJson(Location location);
 }

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -40,6 +40,7 @@ class DuckRouter implements RouterConfig<LocationStack> {
     DuckRouterDeepLinkHandler? onDeepLink,
     DuckRouterNavigatorListener? onNavigate,
     DuckRouterNavigatorObserverBuilder? navigatorObserverBuilder,
+    DuckRestorer? duckRestorer,
   }) {
     return DuckRouter.withConfig(
       configuration: DuckRouterConfiguration(
@@ -48,6 +49,7 @@ class DuckRouter implements RouterConfig<LocationStack> {
         onDeepLink: onDeepLink,
         onNavigate: onNavigate,
         navigatorObserverBuilder: navigatorObserverBuilder,
+        duckRestorer: duckRestorer,
       ),
     );
   }

--- a/duck_router/test/src/restoration_test.dart
+++ b/duck_router/test/src/restoration_test.dart
@@ -1,0 +1,149 @@
+// ignore_for_file: prefer_const_constructors
+
+import 'package:duck_router/duck_router.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('State Restoration', () {
+    testWidgets('should restore locations with their arguments',
+        (tester) async {
+      final restorer = TestDuckRestorer();
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+        duckRestorer: restorer,
+      );
+
+      final router = await createRouter(config, tester);
+      final originalMessage = 'Quack quack';
+      final detailLocation = DetailLocation(message: originalMessage);
+
+      router.navigate(to: detailLocation);
+      await tester.pumpAndSettle();
+      expect(find.text(originalMessage), findsOneWidget);
+
+      // Get the actual restoration data by calling restoreRouteInformation
+      final currentStack = router.routerDelegate.currentConfiguration;
+      final restorationRouteInfo =
+          router.routeInformationParser.restoreRouteInformation(currentStack);
+      expect(restorationRouteInfo, isNotNull);
+
+      final newConfig = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+        duckRestorer: restorer,
+      );
+
+      final newRouter = await createRouter(newConfig, tester);
+      expect(newRouter.configuration.findLocation(detailLocation.path), isNull,
+          reason: 'Fresh router should not have location without restoration');
+
+      final restoredStack = await newRouter.routeInformationParser
+          .parseRouteInformation(restorationRouteInfo!);
+      final restoredDetailLocation =
+          restoredStack.locations.whereType<DetailLocation>().first;
+
+      expect(restoredDetailLocation.message, equals(originalMessage),
+          reason: 'Location parameters should be preserved during restoration');
+
+      newRouter.routerDelegate.setNewRoutePath(restoredStack);
+      await tester.pumpAndSettle();
+      expect(find.text(originalMessage), findsOneWidget,
+          reason: 'Restored location should display with original parameters');
+    });
+
+    testWidgets('should serialize different location parameters differently',
+        (tester) async {
+      final restorer = TestDuckRestorer();
+
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+        duckRestorer: restorer,
+      );
+      final router = await createRouter(config, tester);
+
+      final location1 = DetailLocation(message: 'First Message');
+      final location2 = DetailLocation(message: 'Second Message');
+
+      final codec = LocationStackCodec(configuration: router.configuration);
+      final stack1 = LocationStack(locations: [HomeLocation(), location1]);
+      final stack2 = LocationStack(locations: [HomeLocation(), location2]);
+
+      final encoded1 = codec.encode(stack1);
+      final encoded2 = codec.encode(stack2);
+
+      expect(
+        encoded1,
+        isNot(equals(encoded2)),
+        reason:
+            'Different location parameters should be serialized differently',
+      );
+
+      final locations1 = encoded1['locations'] as List;
+      final locations2 = encoded2['locations'] as List;
+
+      final detail1 = locations1[1] as Map<Object?, Object?>;
+      final detail2 = locations2[1] as Map<Object?, Object?>;
+
+      expect(detail1['path'], equals('detail'));
+      expect(detail2['path'], equals('detail'));
+
+      // Parameters should be serialized
+      expect(detail1['message'], equals('First Message'),
+          reason: 'Location parameters should be serialized');
+      expect(detail2['message'], equals('Second Message'),
+          reason: 'Location parameters should be serialized');
+
+      expect(detail1, isNot(equals(detail2)),
+          reason:
+              'Different parameters should result in different serialized data');
+    });
+
+    testWidgets('Intercepts routes when restoring', (tester) async {
+      final restorer = TestDuckRestorer();
+
+      final config = DuckRouterConfiguration(
+          initialLocation: HomeLocation(), duckRestorer: restorer);
+
+      final router = await createRouter(config, tester);
+      final message = 'Quack quack';
+      final detailLocation = DetailLocation(message: message);
+
+      router.navigate(to: detailLocation);
+      await tester.pumpAndSettle();
+      expect(find.text(message), findsOneWidget);
+
+      final currentStack = router.routerDelegate.currentConfiguration;
+      final restorationRouteInfo =
+          router.routeInformationParser.restoreRouteInformation(currentStack);
+      expect(restorationRouteInfo, isNotNull);
+
+      final newConfig = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+        duckRestorer: restorer,
+        interceptors: [_TestInterceptor()],
+      );
+
+      final newRouter = await createRouter(newConfig, tester);
+      expect(newRouter.configuration.findLocation(detailLocation.path), isNull);
+
+      final restoredStack = await newRouter.routeInformationParser
+          .parseRouteInformation(restorationRouteInfo!);
+
+      newRouter.routerDelegate.setNewRoutePath(restoredStack);
+      await tester.pumpAndSettle();
+      expect(find.byType(Page1Screen), findsOneWidget);
+    });
+  });
+}
+
+class _TestInterceptor extends LocationInterceptor {
+  @override
+  Location? execute(Location to, Location? from) {
+    if (to is DetailLocation) {
+      return Page1Location();
+    }
+
+    return null;
+  }
+}

--- a/duck_router/test/src/test_helpers.dart
+++ b/duck_router/test/src/test_helpers.dart
@@ -286,6 +286,9 @@ class DetailLocation extends Location {
 
   @override
   LocationBuilder get builder => (context) => DetailScreen(message: message);
+
+  @override
+  List<Object?> get props => [path, message];
 }
 
 class DetailScreen extends StatelessWidget {
@@ -417,5 +420,27 @@ class RefreshableApp extends StatelessWidget {
           }
           return child;
         });
+  }
+}
+
+class TestDuckRestorer implements DuckRestorer {
+  @override
+  Location? fromJson(String path, Map<String, dynamic> json) {
+    switch (path) {
+      case 'home':
+        return HomeLocation();
+      case 'detail':
+        return DetailLocation(message: json['message']);
+      default:
+        return null;
+    }
+  }
+
+  @override
+  Map<String, dynamic> toJson(Location l) {
+    if (l is DetailLocation) {
+      return {'message': l.message};
+    }
+    return {};
   }
 }


### PR DESCRIPTION
## Description

We currently support route restoration in the most limited way (paths only). This means arguments are not brought along. This PR introduces `DuckRestorer`, which the user can implement to support restoration in their app. `DuckRestorer` places the complexity of the route translation on the user's side, while abstracting away all the complexity in the routing framework regarding restoration.

## Related Issues

#66

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
