### PR TITLE
fix completer not completed when used with replace

### DIFF
--- a/duck_router/lib/src/configuration.dart
+++ b/duck_router/lib/src/configuration.dart
@@ -85,9 +85,22 @@ class DuckRouterConfiguration {
     }
 
     if (replaced != null) {
+      final replacedCompleter = _routeMapping[replaced.path]?.completer;
+
+      // If we have both a new completer (from the navigate call) and a replaced completer,
+      // we need to chain them so both get completed when the location is popped.
+      Completer? finalCompleter;
+      if (completer != null && replacedCompleter != null) {
+        // Create a combined completer that will complete both when resolved
+        finalCompleter = _createCombinedCompleter(completer, replacedCompleter);
+      } else {
+        // Use whichever completer is available
+        finalCompleter = completer ?? replacedCompleter;
+      }
+
       _routeMapping[location.path] = LocationMatch(
         location: location,
-        completer: _routeMapping[replaced.path]?.completer,
+        completer: finalCompleter,
       );
       _routeMapping.remove(replaced.path);
       return;
@@ -125,9 +138,51 @@ class DuckRouterConfiguration {
     try {
       completer?.complete(value);
     } on TypeError catch (_) {
-      completer?.completeError(InvalidPopTypeException(location, value));
+      completer?.completeError(InvalidPopTypeException(value));
     }
     _routeMapping.remove(location.path);
+  }
+
+  /// Creates a combined completer that will complete both completers with the same result.
+  /// This is used when replacing a location to ensure both the original awaiter and
+  /// the new awaiter get the result when the location is popped.
+  Completer<T> _createCombinedCompleter<T>(
+      Completer<T> newCompleter, Completer replacedCompleter) {
+    final combinedCompleter = Completer<T>();
+
+    combinedCompleter.future.then((value) {
+      // Complete both completers with the same value
+      if (!newCompleter.isCompleted) {
+        try {
+          newCompleter.complete(value);
+        } on TypeError catch (_) {
+          replacedCompleter.completeError(InvalidPopTypeException(value));
+        } catch (e) {
+          // If there's any other error, complete with the error instead
+          newCompleter.completeError(e);
+        }
+      }
+      if (!replacedCompleter.isCompleted) {
+        try {
+          replacedCompleter.complete(value);
+        } on TypeError catch (_) {
+          replacedCompleter.completeError(InvalidPopTypeException(value));
+        } catch (e) {
+          // If there's any other error, complete with the error instead
+          replacedCompleter.completeError(e);
+        }
+      }
+    }).catchError((error, stackTrace) {
+      // Complete both completers with the same error
+      if (!newCompleter.isCompleted) {
+        newCompleter.completeError(error, stackTrace);
+      }
+      if (!replacedCompleter.isCompleted) {
+        replacedCompleter.completeError(error, stackTrace);
+      }
+    });
+
+    return combinedCompleter;
   }
 }
 

--- a/duck_router/lib/src/exception.dart
+++ b/duck_router/lib/src/exception.dart
@@ -24,10 +24,9 @@ class ClearStackException extends DuckRouterException {
 }
 
 class InvalidPopTypeException extends DuckRouterException {
-  final Location location;
   final Object? value;
 
-  const InvalidPopTypeException(this.location, this.value)
+  const InvalidPopTypeException(this.value)
       : super('Trying to return result with pop that does not match the '
             'awaited type. \n'
             'Check the type of the result you are returning. This can also happen '


### PR DESCRIPTION
## Description

Creates a combined completer in case a navigate with replace: true is called, so that both navigate calls' futures complete.

## Related Issues

#69 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
